### PR TITLE
ACP-49: decreased `ProductUpdated` message size

### DIFF
--- a/src/Pyz/Zed/Product/ProductConfig.php
+++ b/src/Pyz/Zed/Product/ProductConfig.php
@@ -74,4 +74,12 @@ class ProductConfig extends SprykerProductConfig
             ProductSearchEvents::ENTITY_SPY_PRODUCT_SEARCH_UPDATE,
         ]);
     }
+
+    /**
+     * @return int
+     */
+    public function getProductPublishToMessageBrokerChunkSize(): int
+    {
+        return 3;
+    }
 }


### PR DESCRIPTION
Decreased `ProductUpdated` message size by decreasing the number of products sent in one message.

#### Overview

- Ticket: https://spryker.atlassian.net/browse/ACP-49
