### PR TITLE
CC-33600: Added fallback for concrete product name in MP dashboard.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -49,7 +49,7 @@
         "spryker-feature/marketplace-merchant-contracts": "^202404.0",
         "spryker-feature/marketplace-merchant-custom-prices": "^202404.0",
         "spryker-feature/marketplace-merchant-order-threshold": "^202404.0",
-        "spryker-feature/marketplace-merchant-portal-product-management": "^202404.0",
+        "spryker-feature/marketplace-merchant-portal-product-management": "dev-master as 202407.0",
         "spryker-feature/marketplace-merchant-portal-product-offer-management": "^202404.0",
         "spryker-feature/marketplace-merchantportal-core": "^202404.0",
         "spryker-feature/marketplace-order-management": "^202404.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "e197896dc1cf2f929a29cb6c1a8fa1b1",
+    "content-hash": "24f4decc8f5f3abd7a1207b5025ebc0f",
     "packages": [
         {
             "name": "async-aws/core",
@@ -6239,7 +6239,7 @@
         },
         {
             "name": "spryker-feature/marketplace-merchant-portal-product-management",
-            "version": "202404.0",
+            "version": "dev-master",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker-feature/marketplace-merchant-portal-product-management.git",
@@ -6259,6 +6259,7 @@
                 "spryker-feature/marketplace-merchantportal-core": "Recommended feature dependency.",
                 "spryker-feature/marketplace-product": "Recommended feature dependency."
             },
+            "default-branch": true,
             "type": "metapackage",
             "extra": {
                 "branch-alias": {
@@ -49678,16 +49679,16 @@
         },
         {
             "name": "spryker/product-merchant-portal-gui",
-            "version": "4.0.0",
+            "version": "4.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker/product-merchant-portal-gui.git",
-                "reference": "3b12cddd0143aee4b1335c2bf4a934d897f0122c"
+                "reference": "88c53062d32cbbd5cd768190f13d7fd756224cca"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker/product-merchant-portal-gui/zipball/3b12cddd0143aee4b1335c2bf4a934d897f0122c",
-                "reference": "3b12cddd0143aee4b1335c2bf4a934d897f0122c",
+                "url": "https://api.github.com/repos/spryker/product-merchant-portal-gui/zipball/88c53062d32cbbd5cd768190f13d7fd756224cca",
+                "reference": "88c53062d32cbbd5cd768190f13d7fd756224cca",
                 "shasum": ""
             },
             "require": {
@@ -49748,9 +49749,9 @@
             ],
             "description": "ProductMerchantPortalGui module",
             "support": {
-                "source": "https://github.com/spryker/product-merchant-portal-gui/tree/4.0.0"
+                "source": "https://github.com/spryker/product-merchant-portal-gui/tree/4.1.0"
             },
-            "time": "2024-04-03T13:26:42+00:00"
+            "time": "2024-05-16T14:02:12+00:00"
         },
         {
             "name": "spryker/product-merchant-portal-gui-extension",
@@ -76884,11 +76885,18 @@
             "version": "9999999-dev",
             "alias": "202407.0",
             "alias_normalized": "202407.0"
+        },
+        {
+            "package": "spryker-feature/marketplace-merchant-portal-product-management",
+            "version": "9999999-dev",
+            "alias": "202407.0",
+            "alias_normalized": "202407.0"
         }
     ],
     "minimum-stability": "dev",
     "stability-flags": {
         "spryker-feature/customer-account-management": 20,
+        "spryker-feature/marketplace-merchant-portal-product-management": 20,
         "spryker/cypress-tests": 20,
         "spryker/docker-chromedriver": 20,
         "spryker/robotframework-suite-tests": 20


### PR DESCRIPTION
#### Overview

- Ticket: https://spryker.atlassian.net/browse/CC-33600

