### PR TITLE
POC for multiselect attributes values

### DIFF
--- a/src/Pyz/Shared/ProductAttribute/ProductAttributeConfig.php
+++ b/src/Pyz/Shared/ProductAttribute/ProductAttributeConfig.php
@@ -1,0 +1,20 @@
+<?php
+
+/**
+ * This file is part of the Spryker Commerce OS.
+ * For full license information, please view the LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Pyz\Shared\ProductAttribute;
+
+use Spryker\Shared\ProductAttribute\ProductAttributeConfig as ProductAttributeConfigAlias;
+
+class ProductAttributeConfig extends ProductAttributeConfigAlias
+{
+    /**
+     * @var string
+     */
+    public const INPUT_TYPE_MULTISELECT = 'multiselect';
+}

--- a/src/Pyz/Yves/ProductDetailPage/Theme/default/components/molecules/product-detail/product-detail.twig
+++ b/src/Pyz/Yves/ProductDetailPage/Theme/default/components/molecules/product-detail/product-detail.twig
@@ -29,7 +29,7 @@
                 {% if name %}
                     <div class="col col--sm-6 {{ config.name }}__detail-list-item" itemprop="additionalProperty" itemscope itemtype="https://schema.org/PropertyValue">
                         <div class="{{ config.name }}__detail-list-key" itemprop="name">{{ ('product.attribute.' ~ name) | trans }}</div>
-                        <div class="{{ config.name }}__detail-list-value" itemprop="value">{{ value }}</div>
+                        <div class="{{ config.name }}__detail-list-value" itemprop="value">{{ value | join(',') }}</div>
                     </div>
                 {% endif %}
             {% endfor %}

--- a/src/Pyz/Zed/ProductAttribute/ProductAttributeConfig.php
+++ b/src/Pyz/Zed/ProductAttribute/ProductAttributeConfig.php
@@ -1,0 +1,26 @@
+<?php
+
+/**
+ * This file is part of the Spryker Commerce OS.
+ * For full license information, please view the LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Pyz\Zed\ProductAttribute;
+
+use Pyz\Shared\ProductAttribute\ProductAttributeConfig as SharedProductAttributeConfig;
+use Spryker\Zed\ProductAttribute\ProductAttributeConfig as SprykerProductAttributeConfig;
+
+class ProductAttributeConfig extends SprykerProductAttributeConfig
+{
+    public function getAttributeAvailableTypes(): array
+    {
+        return array_merge(
+            parent::getAttributeAvailableTypes(),
+            [
+                SharedProductAttributeConfig::INPUT_TYPE_MULTISELECT => SharedProductAttributeConfig::INPUT_TYPE_MULTISELECT,
+            ],
+        );
+    }
+}

--- a/src/Pyz/Zed/ProductAttributeGui/Presentation/View/_partials/attribute-table.twig
+++ b/src/Pyz/Zed/ProductAttributeGui/Presentation/View/_partials/attribute-table.twig
@@ -1,0 +1,109 @@
+<div class="table-responsive">
+    <table class="table table-striped table-bordered table-hover gui-table-data" id="productAttributesTable"
+           data-paging="false">
+        <form id="attribute_values_form" method="post" class="kv_autocomplete_form" action="{{ formActionUrl }}">
+            <input type="hidden" name="attribute_values_form[hidden_product_abstract_id]"
+                   id="attribute_values_form_hidden_product_abstract_id" value="{{ idProductAbstract }}"/>
+            <input type="hidden" name="attribute_values_form[hidden_product_id]"
+                   id="attribute_values_form_hidden_product_id" value="{{ idProductConcrete }}"/>
+            {{ form_widget(csrfForm) }}
+            <thead>
+            <tr>
+                <th>Key</th>
+                {% for localeCode,localeData in locales %}
+                    {% if localeCode == '_' %}
+                        <th>{{ 'Default' }}</th>
+                    {% else %}
+                        <th>{{ localeData.locale_name }}</th>
+                    {% endif %}
+                {% endfor %}
+                <th>Action</th>
+            </tr>
+            </thead>
+            <tbody>
+            {% for key in productAttributeKeys %}
+                {% set idAttribute = metaAttributes[key]['attribute_id'] %}
+                {% set allowInput = metaAttributes[key]['allow_input'] %}
+                {% set isSuper = metaAttributes[key]['is_super'] %}
+
+                {% set isReadOnly = false %}
+                {% if isSuper or idAttribute is empty %}
+                    {% set isReadOnly = true %}
+                    {% set allowInput = false %}
+                {% endif %}
+                <tr {% if isSuper %} {{ 'style="display: none"' }} {% endif %}>
+                    <td style="vertical-align: middle;">
+                        {% if isSuper %}
+                            <strong>{{ key }}</strong>
+                        {% else %}
+                            {{ key }}
+                        {% endif %}
+                    </td>
+                    {% for localeData in locales %}
+                        {% set localeCode = localeData.locale_name %}
+                        {% set name = '[' ~ key ~ ']' %}
+                        {% set id = key %}
+
+                        {% if localeCode != '_' %}
+                            {% set name = name ~ '[' ~ localeCode ~ ']' %}
+                            {% set id = id ~ '_' ~ localeCode %}
+                        {% endif %}
+
+                        {% set inputName = 'attribute_values_form' ~ name %}
+                        {% set inputId = 'attribute_values_form_' ~ id %}
+                        {% if productAttributes[localeCode][key] is defined %}
+                            {% set attributeValue = productAttributes[localeCode][key] | join(',') %}
+                            <td>
+                                <input
+                                    {% if isReadOnly %}
+                                        readonly="readonly"
+                                    {% endif %}
+                                    id="{{ inputId }}"
+                                    name="{{ inputName }}"
+                                    type="text"
+                                    class="spryker-form-autocomplete form-control ui-autocomplete-input kv_attribute_autocomplete"
+                                    value="{{ attributeValue }}"
+                                    data-allow_input="{{ allowInput }}"
+                                    data-is_super="{{ isSuper }}"
+                                    data-is_read_only="{{ isReadOnly }}"
+                                    data-attribute_key="{{ key }}"
+                                    data-is_attribute_input
+                                    data-id_attribute="{{ idAttribute }}"
+                                    data-locale_code="{{ localeData['locale_name'] }}"
+                                /><span style="display: none">{{ attributeValue }}</span>
+                            </td>
+                        {% else %}
+                            <td>
+                                <input
+                                    {% if isReadOnly %}
+                                        readonly="readonly"
+                                    {% endif %}
+                                    id="{{ inputId }}"
+                                    name="{{ inputName }}"
+                                    type="text"
+                                    class="spryker-form-autocomplete form-control ui-autocomplete-input kv_attribute_autocomplete"
+                                    value=""
+                                    data-allow_input="{{ allowInput }}"
+                                    data-is_super="{{ isSuper }}"
+                                    data-is_read_only="{{ isReadOnly }}"
+                                    data-attribute_key="{{ key }}"
+                                    data-is_attribute_input
+                                    data-id_attribute="{{ idAttribute }}"
+                                    data-locale_code="{{ localeData['locale_name'] }}"
+                                />
+                                <span style="display: none"></span>
+                            </td>
+                        {% endif %}
+                    {% endfor %}
+                    <td style="vertical-align: middle; text-align: left;">
+                        {% if isSuper == false %}
+                            <a data-key="{{ key }}" href="#"
+                               class="btn btn-xs btn-outline btn-danger remove-item">{{ 'Remove' | trans }}</a>
+                        {% endif %}
+                    </td>
+                </tr>
+            {% endfor %}
+            </tbody>
+        </form>
+    </table>
+</div>

--- a/src/Pyz/Zed/ProductSearch/Business/Map/ProductSearchAttributeMapper.php
+++ b/src/Pyz/Zed/ProductSearch/Business/Map/ProductSearchAttributeMapper.php
@@ -1,0 +1,50 @@
+<?php
+
+/**
+ * This file is part of the Spryker Commerce OS.
+ * For full license information, please view the LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Pyz\Zed\ProductSearch\Business\Map;
+
+use Generated\Shared\Transfer\PageMapTransfer;
+use Spryker\Zed\ProductSearch\Business\Map\Collector\ProductSearchAttributeMapCollectorInterface;
+use Spryker\Zed\ProductSearch\Business\Map\ProductSearchAttributeMapper as SprykerProductSearchAttributeMapper;
+use Spryker\Zed\Search\Business\Model\Elasticsearch\DataMapper\PageMapBuilderInterface;
+
+class ProductSearchAttributeMapper extends SprykerProductSearchAttributeMapper
+{
+    protected function runAttributeMapCollector(
+        ProductSearchAttributeMapCollectorInterface $attributeMapCollector,
+        PageMapBuilderInterface $pageMapBuilder,
+        PageMapTransfer $pageMapTransfer,
+        array $attributes,
+    ): PageMapTransfer {
+        $attributeMap = $attributeMapCollector->getProductSearchAttributeMap();
+
+        foreach ($attributeMap as $attributeMapTransfer) {
+            $attributeName = $attributeMapTransfer->getAttributeName();
+
+            if (!isset($attributes[$attributeName])) {
+                continue;
+            }
+
+            foreach ($attributeMapTransfer->getTargetFields() as $targetFieldName) {
+                $value = $attributes[$attributeName];
+                if (!is_array($value)) {
+                    $pageMapBuilder->add($pageMapTransfer, $targetFieldName, $attributeName, $value);
+
+                    continue;
+                }
+
+                foreach ($value as $item) {
+                    $pageMapBuilder->add($pageMapTransfer, $targetFieldName, $attributeName, $item);
+                }
+            }
+        }
+
+        return $pageMapTransfer;
+    }
+}

--- a/src/Pyz/Zed/ProductSearch/Business/ProductSearchBusinessFactory.php
+++ b/src/Pyz/Zed/ProductSearch/Business/ProductSearchBusinessFactory.php
@@ -1,0 +1,27 @@
+<?php
+
+/**
+ * This file is part of the Spryker Commerce OS.
+ * For full license information, please view the LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Pyz\Zed\ProductSearch\Business;
+
+use Pyz\Zed\ProductSearch\Business\Map\ProductSearchAttributeMapper;
+use Spryker\Zed\ProductSearch\Business\Map\ProductSearchAttributeMapperInterface;
+use Spryker\Zed\ProductSearch\Business\ProductSearchBusinessFactory as SprykerProductSearchBusinessFactory;
+
+/**
+ * @method \Spryker\Zed\ProductSearch\Persistence\ProductSearchRepositoryInterface getRepository()
+ * @method \Spryker\Zed\ProductSearch\ProductSearchConfig getConfig()
+ * @method \Spryker\Zed\ProductSearch\Persistence\ProductSearchQueryContainerInterface getQueryContainer()
+ */
+class ProductSearchBusinessFactory extends SprykerProductSearchBusinessFactory
+{
+    public function createProductSearchAttributeMapper(): ProductSearchAttributeMapperInterface
+    {
+        return new ProductSearchAttributeMapper($this->getAttributeMapCollectors());
+    }
+}


### PR DESCRIPTION
Draft POC for multiselect manageable attributes type, doesn't include:
- input (BO / MP)
- output (MP / Storefront)

Multiselect attributes should be saved internally as an array.
See: https://spryker.atlassian.net/wiki/spaces/CORE/pages/991100973/Product+Attribute+Multi-Value+-+Implementation+Plan