### PR TITLE
Update Jenkins version to 2.493.2

### DIFF
--- a/deploy.aop-b2b-testing.yml
+++ b/deploy.aop-b2b-testing.yml
@@ -221,6 +221,7 @@ services:
                 protocol: tcp
     scheduler:
         engine: jenkins
+        version: '2.492.3'
         csrf-protection-enabled: true
         endpoints:
             jenkins.aop-b2b-testing.demo-spryker.com:

--- a/deploy.aop-consultant-b2c.yml
+++ b/deploy.aop-consultant-b2c.yml
@@ -237,6 +237,7 @@ services:
                 protocol: tcp
     scheduler:
         engine: jenkins
+        version: '2.492.3'
         csrf-protection-enabled: true
         endpoints:
             scheduler.consultant-b2c.demo-spryker.com:

--- a/deploy.aop-demoshop-b2b.yml
+++ b/deploy.aop-demoshop-b2b.yml
@@ -189,6 +189,7 @@ services:
                 protocol: tcp
     scheduler:
         engine: jenkins
+        version: '2.492.3'
         csrf-protection-enabled: true
         endpoints:
             scheduler.aop-b2b.demo-spryker.com:

--- a/deploy.aws-env-template.yml
+++ b/deploy.aws-env-template.yml
@@ -217,6 +217,7 @@ services:
                 protocol: tcp
     scheduler:
         engine: jenkins
+        version: '2.492.3'
         endpoints:
             scheduler.example.cloud.spryker.toys:
     mail_catcher:

--- a/deploy.ci.acceptance.mariadb.prefer-lowest.yml
+++ b/deploy.ci.acceptance.mariadb.prefer-lowest.yml
@@ -113,7 +113,7 @@ services:
         version: '6.8'
     scheduler:
         engine: jenkins
-        version: '2.442'
+        version: '2.492.3'
         csrf-protection-enabled: true
     mail_catcher:
         engine: mailhog

--- a/deploy.ci.functional.mariadb.prefer-lowest.yml
+++ b/deploy.ci.functional.mariadb.prefer-lowest.yml
@@ -115,7 +115,7 @@ services:
         version: '6.8'
     scheduler:
         engine: jenkins
-        version: '2.442'
+        version: '2.492.3'
         csrf-protection-enabled: true
     mail_catcher:
         engine: mailhog

--- a/deploy.dev.dynamic-store-off.yml
+++ b/deploy.dev.dynamic-store-off.yml
@@ -265,7 +265,7 @@ services:
                 protocol: tcp
     scheduler:
         engine: jenkins
-        version: '2.442'
+        version: '2.492.3'
         csrf-protection-enabled: true
         endpoints:
             scheduler.spryker.local:

--- a/deploy.dev.yml
+++ b/deploy.dev.yml
@@ -230,7 +230,7 @@ services:
                 protocol: tcp
     scheduler:
         engine: jenkins
-        version: '2.442'
+        version: '2.492.3'
         csrf-protection-enabled: true
         endpoints:
             scheduler.spryker.local:

--- a/deploy.dynamic-store-off.yml
+++ b/deploy.dynamic-store-off.yml
@@ -249,7 +249,7 @@ services:
                 protocol: tcp
     scheduler:
         engine: jenkins
-        version: '2.442'
+        version: '2.492.3'
         csrf-protection-enabled: true
         endpoints:
             scheduler.spryker.local:

--- a/deploy.scos2-b2bmp.yml
+++ b/deploy.scos2-b2bmp.yml
@@ -145,7 +145,7 @@ services:
                 protocol: tcp
     scheduler:
         engine: jenkins
-        version: '2.442'
+        version: '2.492.3'
         endpoints:
             scheduler.spryker-b2bmp.cloud.spryker.toys:
     mail_catcher:

--- a/deploy.spryker-mp-b2b.yml
+++ b/deploy.spryker-mp-b2b.yml
@@ -221,6 +221,7 @@ services:
                 protocol: tcp
     scheduler:
         engine: jenkins
+        version: '2.492.3'
         endpoints:
             scheduler.mp-b2b.internal-testing.demo-spryker.com:
     mail_catcher:

--- a/deploy.spryker-mpb2bs.yml
+++ b/deploy.spryker-mpb2bs.yml
@@ -179,7 +179,7 @@ services:
                 protocol: tcp
     scheduler:
         engine: jenkins
-        version: '2.442'
+        version: '2.492.3'
         csrf-protection-enabled: true
         endpoints:
             scheduler.mp-b2b.internal-security.demo-spryker.com:

--- a/deploy.spryker-scosb2bmp.yml
+++ b/deploy.spryker-scosb2bmp.yml
@@ -193,7 +193,7 @@ services:
                 protocol: tcp
     scheduler:
         engine: jenkins
-        version: '2.442'
+        version: '2.492.3'
         csrf-protection-enabled: true
         endpoints:
             scheduler.scos-b2bmp.sh01.demo-spryker.com:

--- a/deploy.yml
+++ b/deploy.yml
@@ -217,7 +217,7 @@ services:
                 protocol: tcp
     scheduler:
         engine: jenkins
-        version: '2.442'
+        version: '2.492.3'
         csrf-protection-enabled: true
         endpoints:
             scheduler.spryker.local:


### PR DESCRIPTION
#### Overview

- Ticket: https://spryker.atlassian.net/browse/FRW-10275

###### Change log

- Introduce Jenkins 2.492.3 as the default scheduler version.
