### PR TITLE
CC-35577: add US country to DE store for ACP tests

### DIFF
--- a/config/Shared/stores.php
+++ b/config/Shared/stores.php
@@ -39,7 +39,7 @@ if (getenv('SPRYKER_ACTIVE_STORES')) {
             'de' => 'de_DE',
         ],
         // first entry is default
-        'countries' => ['DE', 'AT', 'NO', 'CH', 'ES', 'GB'],
+        'countries' => ['DE', 'AT', 'NO', 'CH', 'ES', 'GB', 'US'],
         // internal and shop
         'currencyIsoCode' => 'EUR',
         'currencyIsoCodes' => ['EUR', 'CHF'],

--- a/data/import/common/DE/country_store.csv
+++ b/data/import/common/DE/country_store.csv
@@ -1,3 +1,5 @@
 store_name,country
 DE,DE
 DE,CH
+DE,GB
+DE,US

--- a/data/import/common/common/glossary.csv
+++ b/data/import/common/common/glossary.csv
@@ -817,6 +817,8 @@ countries.iso.ES,Spain,en_US
 countries.iso.ES,Spanien,de_DE
 countries.iso.GB,United Kingdom,en_US
 countries.iso.GB,Großbritannien,de_DE
+countries.iso.US,United States,en_US
+countries.iso.US,Vereinigte Staaten,de_DE
 customer.billingSameAsShipping,Billing address same as shipping address,en_US
 customer.billingSameAsShipping,Liefer- und Rechnungsadresse sind gleich,de_DE
 checkout.customer.proceed_as_user,Proceed as a registered user (sign up),en_US


### PR DESCRIPTION
#### Overview

- Ticket: [CC-35577](https://spryker.atlassian.net/browse/CC-35577)

#### Related PRs
- https://github.com/spryker-shop/b2b-demo-shop/pull/649
- https://github.com/spryker-shop/b2c-demo-shop/pull/688
- https://github.com/spryker-shop/b2c-demo-marketplace/pull/566
- https://github.com/spryker-projects/acp-e2e-testing/pull/82

###### Change log
- added US country to DE store in config
- added US and UK countries to DE store
- added glossary translations for US country name
