### PR TITLE
CC-35775 Remove obsolete CI jobs.

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -9,3 +9,8 @@
 ###### Change log
 
 {Relevant changes for project level go here.}
+
+###### CI Notice
+Tests do **not** run automatically on every PR.
+To trigger the required test suites, please add the appropriate label(s) to your PR.
+For the full list of labels and their associated tests, see our Confluence page: [CI Test Labels & Triggers](https://spryker.atlassian.net/wiki/spaces/Framework/pages/4715216905/Using+PR+labels+to+control+CI+runs+for+project+repositories)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -225,11 +225,10 @@ jobs:
                 if: always()
 
     php-83-mariadb-glue-alpine:
-        name: "PHP 8.3 / MariaDB / Glue / Alpine"
+        name: "[run-api-ci] PHP 8.3 / MariaDB / Glue / Alpine"
         if: >
-            !contains(github.event.pull_request.head.ref, 'hackathon')
-            && (contains(github.event.pull_request.labels.*.name, 'run-api-ci')
-                || contains(github.event.pull_request.labels.*.name, 'run-latest-ci'))
+            contains(github.event.pull_request.labels.*.name, 'run-api-ci')
+            || contains(github.event.pull_request.labels.*.name, 'run-latest-ci')
             || github.ref == 'refs/heads/master'
         runs-on: ubuntu-22.04
         env:
@@ -295,8 +294,7 @@ jobs:
     php-83-postgresql-glue-alpine:
         name: "PHP 8.3 / PostgreSQL / Glue / Alpine"
         if: >
-            !contains(github.event.pull_request.head.ref, 'hackathon')
-            && contains(github.event.pull_request.labels.*.name, 'run-compatibility-ci')
+            contains(github.event.pull_request.labels.*.name, 'run-compatibility-ci')
             || github.ref == 'refs/heads/master'
         runs-on: ubuntu-22.04
         env:
@@ -359,11 +357,10 @@ jobs:
                 if: always()
 
     php-83-mariadb-acceptance-alpine:
-        name: "PHP 8.3 / MariaDB / Acceptance / Alpine"
+        name: "[run-ui-ci] PHP 8.3 / MariaDB / Acceptance / Alpine"
         if: >
-            !contains(github.event.pull_request.head.ref, 'hackathon')
-            && (contains(github.event.pull_request.labels.*.name, 'run-ui-ci')
-                || contains(github.event.pull_request.labels.*.name, 'run-latest-ci'))
+            contains(github.event.pull_request.labels.*.name, 'run-ui-ci')
+            || contains(github.event.pull_request.labels.*.name, 'run-latest-ci')
             || github.ref == 'refs/heads/master'
         runs-on: ubuntu-22.04
         env:
@@ -426,8 +423,7 @@ jobs:
 
     php-83-postgresql-acceptance-alpine:
         if: >
-            !contains(github.event.pull_request.head.ref, 'hackathon')
-            && contains(github.event.pull_request.labels.*.name, 'run-compatibility-ci')
+            contains(github.event.pull_request.labels.*.name, 'run-compatibility-ci')
             || github.ref == 'refs/heads/master'
         name: "PHP 8.3 / PostgreSQL / Acceptance / Alpine"
         runs-on: ubuntu-22.04
@@ -493,7 +489,7 @@ jobs:
             contains(github.event.pull_request.labels.*.name, 'run-functional-ci')
             || contains(github.event.pull_request.labels.*.name, 'run-latest-ci')
             || github.ref == 'refs/heads/master'
-        name: "PHP 8.3 / MariaDB / Functional / Alpine"
+        name: "[run-functional-ci] PHP 8.3 / MariaDB / Functional / Alpine"
         runs-on: ubuntu-22.04
         env:
             PROGRESS_TYPE: plain
@@ -554,8 +550,7 @@ jobs:
 
     php-83-postgresql-functional-alpine:
         if: >
-            !contains(github.event.pull_request.head.ref, 'hackathon')
-            && contains(github.event.pull_request.labels.*.name, 'run-compatibility-ci')
+            contains(github.event.pull_request.labels.*.name, 'run-compatibility-ci')
             || github.ref == 'refs/heads/master'
         name: "PHP 8.3 / PostgreSQL / Functional / Alpine"
         runs-on: ubuntu-22.04
@@ -749,8 +744,7 @@ jobs:
 
     php-82-postgresql-functional-alpine:
         if: >
-            !contains(github.event.pull_request.head.ref, 'hackathon')
-            && contains(github.event.pull_request.labels.*.name, 'run-compatibility-ci')
+            contains(github.event.pull_request.labels.*.name, 'run-compatibility-ci')
             || github.ref == 'refs/heads/master'
         name: "PHP 8.2 / PostgreSQL / Functional / Alpine"
         runs-on: ubuntu-22.04
@@ -814,8 +808,7 @@ jobs:
 
     php-82-mariadb-acceptance-alpine:
         if: >
-            !contains(github.event.pull_request.head.ref, 'hackathon')
-            && contains(github.event.pull_request.labels.*.name, 'run-compatibility-ci')
+            contains(github.event.pull_request.labels.*.name, 'run-compatibility-ci')
             || github.ref == 'refs/heads/master'
         name: "PHP 8.2 / MariaDB / Acceptance / Alpine"
         runs-on: ubuntu-22.04
@@ -878,8 +871,7 @@ jobs:
 
     php-82-mariadb-functional-alpine:
         if: >
-            !contains(github.event.pull_request.head.ref, 'hackathon')
-            && contains(github.event.pull_request.labels.*.name, 'run-compatibility-ci')
+            contains(github.event.pull_request.labels.*.name, 'run-compatibility-ci')
             || github.ref == 'refs/heads/master'
         name: "PHP 8.2 / MariaDB / Functional / Alpine"
         runs-on: ubuntu-22.04
@@ -941,8 +933,7 @@ jobs:
 
     php-82-postgres-functional-debian:
         if: >
-            !contains(github.event.pull_request.head.ref, 'hackathon')
-            && contains(github.event.pull_request.labels.*.name, 'run-compatibility-ci')
+            contains(github.event.pull_request.labels.*.name, 'run-compatibility-ci')
             || github.ref == 'refs/heads/master'
         name: "PHP 8.2 / PostgreSQL / Functional / Debian"
         runs-on: ubuntu-22.04
@@ -974,11 +965,10 @@ jobs:
 
     frontend-assets-via-docker-php-8-2:
         if: >
-            !contains(github.event.pull_request.head.ref, 'hackathon')
-            && (contains(github.event.pull_request.labels.*.name, 'run-functional-ci')
-                || contains(github.event.pull_request.labels.*.name, 'run-latest-ci'))
+            contains(github.event.pull_request.labels.*.name, 'run-functional-ci')
+            || contains(github.event.pull_request.labels.*.name, 'run-latest-ci')
             || github.ref == 'refs/heads/master'
-        name: "Docker / Alpine / PHP 8.2 / Frontend & Assets"
+        name: "[run-functional-ci] PHP 8.2 / Frontend & Assets"
         runs-on: ubuntu-22.04
         env:
             PROGRESS_TYPE: plain
@@ -1001,12 +991,11 @@ jobs:
                 uses: ./.github/actions/job-slack-notifications
                 if: always()
 
-    docker-alpine-php-82-mariadb-robot-dynamic-store-off:
+    docker-alpine-php-82-postgresql-robot-dynamic-store-off:
         if: >
-            !contains(github.event.pull_request.head.ref, 'hackathon')
-            && contains(github.event.pull_request.labels.*.name, 'run-compatibility-ci')
+            contains(github.event.pull_request.labels.*.name, 'run-compatibility-ci')
             || github.ref == 'refs/heads/master'
-        name: "Docker / Alpine / PHP 8.2 / MariaDB / Robot / API / Dynamic Store OFF"
+        name: "Docker / Alpine / PHP 8.2 / PostgreSQL / Robot / API / Dynamic Store OFF"
         runs-on: ubuntu-22.04
         env:
             PROGRESS_TYPE: plain
@@ -1033,7 +1022,7 @@ jobs:
                 continue-on-error: true
                 run: |
                     git clone https://github.com/spryker/docker-sdk.git ./docker
-                    docker/sdk boot deploy.ci.acceptance.mariadb.dynamic-store-off.yml
+                    docker/sdk boot deploy.ci.acceptance.dynamic-store-off.yml
                     sudo bash -c "echo '127.0.0.1 backend-api.at.spryker.local backend-api.de.spryker.local glue-backend.de.spryker.local glue-backend.at.spryker.local glue-storefront.de.spryker.local glue-storefront.at.spryker.local backend-gateway.at.spryker.local backend-gateway.de.spryker.local backoffice.at.spryker.local backoffice.de.spryker.local date-time-configurator-example.spryker.local glue.at.spryker.local glue.de.spryker.local yves.at.spryker.local yves.de.spryker.local mp.de.spryker.local mp.at.spryker.local' >> /etc/hosts"
                     docker/sdk up -t
                     docker/sdk cli composer dump-autoload -o -a --apcu
@@ -1041,63 +1030,11 @@ jobs:
                     APPLICATION_STORE=AT docker/sdk console queue:worker:start --stop-when-empty
             -   name: Run Tests
                 run: |
-                    docker/sdk exec robot-framework robot -v env:api_mp_b2b -v docker:True --exclude skip-due-to-issueORskip-due-to-refactoring -d results -s robotframework.tests.api.mp_b2b .
+                    docker/sdk exec robot-framework robot -v env:api_mp_b2b -v db_engine:psycopg2 -v docker:True --exclude skip-due-to-issueORskip-due-to-refactoring -d results -s robotframework.tests.api.mp_b2b .
             -   name: Upload artifacts
                 if: failure()
                 run: |
-                    AWS_DEFAULT_REGION=${{env.ROBOT_TESTS_ARTIFACTS_BUCKET_REGION}} AWS_ACCESS_KEY_ID=${{ secrets.ROBOT_TESTS_ARTIFACTS_KEY }} AWS_SECRET_ACCESS_KEY=${{ secrets.ROBOT_TESTS_ARTIFACTS_SECRET }} aws s3 cp .robot/results/log.html s3://${{vars.ROBOT_TESTS_ARTIFACTS_BUCKET}}/b2b-mp/dms-off/robot-api/${GITHUB_RUN_ID}/PHP8.2MariaDB/log.html
-
-            -   name: Slack Notification for failed job
-                uses: ./.github/actions/job-slack-notifications
-                if: always()
-
-    docker-alpine-php-83-postgresql-robot:
-        if: >
-            !contains(github.event.pull_request.head.ref, 'hackathon')
-            && contains(github.event.pull_request.labels.*.name, 'run-compatibility-ci')
-            || github.ref == 'refs/heads/master'
-        name: "Docker / Alpine / PHP 8.3 / PostgreSQL / Robot / API"
-        runs-on: ubuntu-22.04
-        env:
-            PROGRESS_TYPE: plain
-            SPRYKER_PLATFORM_IMAGE: spryker/php:8.3
-            TRAVIS: 1
-            ROBOT_TESTS_ARTIFACTS_BUCKET_REGION: eu-west-1
-            SPRYKER_CURRENT_REGION: EU
-            DYNAMIC_STORE_MODE: true
-        steps:
-            -   uses: actions/checkout@v4
-            -   name: Install packages
-                run: |
-                    sudo apt-get update
-                    sudo apt install awscli -q
-
-            -   name: Install robotframework-suite-tests folder
-                run: |
-                    cd ./data && composer require "spryker/robotframework-suite-tests:dev-master" --dev --no-interaction
-                    cp -r vendor ../vendor
-
-            -   name: Install docker-compose
-                run: |
-                    sudo curl -L "https://github.com/docker/compose/releases/download/2.12.0/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
-                    sudo chmod +x /usr/local/bin/docker-compose
-            -   name: Install Project
-                continue-on-error: true
-                run: |
-                    git clone https://github.com/spryker/docker-sdk.git ./docker
-                    docker/sdk boot deploy.ci.acceptance.yml
-                    sudo bash -c "echo '127.0.0.1 backend-api.eu.spryker.local backend-api.us.spryker.local backend-gateway.eu.spryker.local backend-gateway.us.spryker.local backoffice.eu.spryker.local backoffice.us.spryker.local glue-backend.eu.spryker.local glue-backend.us.spryker.local glue-storefront.eu.spryker.local glue-storefront.us.spryker.local glue.eu.spryker.local glue.us.spryker.local mail.spryker.local mp.eu.spryker.local mp.us.spryker.local queue.spryker.local spryker.local swagger.spryker.local yves.eu.spryker.local yves.us.spryker.local' >> /etc/hosts"
-                    docker/sdk up -t
-                    docker/sdk cli composer dump-autoload -o -a --apcu
-                    docker/sdk testing console queue:worker:start --stop-when-empty
-                    docker/sdk console queue:worker:start --stop-when-empty
-            -   name: Run Tests
-                run: |
-                    docker/sdk exec robot-framework robot -v env:api_mp_b2b -v db_engine:psycopg2 -v docker:True -v dms:true -v glue_env:http://glue.eu.spryker.local -v bapi_env:http://glue-backend.eu.spryker.local -v sapi_env:http://glue-storefront.eu.spryker.local --exclude skip-due-to-issueORskip-due-to-refactoring -d results -s robotframework.tests.api.mp_b2b .
-            -   name: Upload artifacts
-                if: failure()
-                run: |
-                    AWS_DEFAULT_REGION=${{env.ROBOT_TESTS_ARTIFACTS_BUCKET_REGION}} AWS_ACCESS_KEY_ID=${{ secrets.ROBOT_TESTS_ARTIFACTS_KEY }} AWS_SECRET_ACCESS_KEY=${{ secrets.ROBOT_TESTS_ARTIFACTS_SECRET }} aws s3 cp .robot/results/log.html s3://${{vars.ROBOT_TESTS_ARTIFACTS_BUCKET}}/b2b-mp/dms-on/robot-api/${GITHUB_RUN_ID}/PHP8.3PostgreSQL/log.html
+                    AWS_DEFAULT_REGION=${{env.ROBOT_TESTS_ARTIFACTS_BUCKET_REGION}} AWS_ACCESS_KEY_ID=${{ secrets.ROBOT_TESTS_ARTIFACTS_KEY }} AWS_SECRET_ACCESS_KEY=${{ secrets.ROBOT_TESTS_ARTIFACTS_SECRET }} aws s3 cp .robot/results/log.html s3://${{vars.ROBOT_TESTS_ARTIFACTS_BUCKET}}/b2b-mp/dms-off/robot-api/${GITHUB_RUN_ID}/PHP8.2PostgresSQL/log.html
 
             -   name: Slack Notification for failed job
                 uses: ./.github/actions/job-slack-notifications
@@ -1105,11 +1042,10 @@ jobs:
 
     docker-alpine-php-83-mariadb-robot:
         if: >
-            !contains(github.event.pull_request.head.ref, 'hackathon')
-            && (contains(github.event.pull_request.labels.*.name, 'run-api-ci')
-                || contains(github.event.pull_request.labels.*.name, 'run-latest-ci'))
+            contains(github.event.pull_request.labels.*.name, 'run-api-ci')
+            || contains(github.event.pull_request.labels.*.name, 'run-latest-ci')
             || github.ref == 'refs/heads/master'
-        name: "Docker / Alpine / PHP 8.3 / MariaDB / Robot / API"
+        name: "[run-api-ci] PHP 8.3 / MariaDB / Robot / API"
         runs-on: ubuntu-22.04
         env:
             PROGRESS_TYPE: plain
@@ -1157,8 +1093,7 @@ jobs:
 
     docker-alpine-php-8-3-mariadb-cypress-dynamic-store-off:
         if: >
-            !contains(github.event.pull_request.head.ref, 'hackathon')
-            && contains(github.event.pull_request.labels.*.name, 'run-compatibility-ci')
+            contains(github.event.pull_request.labels.*.name, 'run-compatibility-ci')
             || github.ref == 'refs/heads/master'
         name: "Docker / Alpine / PHP 8.3 / MariaDB / Cypress / UI / Dynamic Store OFF"
         runs-on: ubuntu-22.04
@@ -1215,11 +1150,10 @@ jobs:
 
     docker-alpine-php-83-mariadb-cypress:
         if: >
-            !contains(github.event.pull_request.head.ref, 'hackathon')
-            && (contains(github.event.pull_request.labels.*.name, 'run-ui-ci')
-                || contains(github.event.pull_request.labels.*.name, 'run-latest-ci'))
+            contains(github.event.pull_request.labels.*.name, 'run-ui-ci')
+            || contains(github.event.pull_request.labels.*.name, 'run-latest-ci')
             || github.ref == 'refs/heads/master'
-        name: "Docker / Alpine / PHP 8.3 / MariaDB / Cypress / UI"
+        name: "[run-ui-ci] PHP 8.3 / MariaDB / Cypress / UI"
         runs-on: ubuntu-22.04
         env:
             PROGRESS_TYPE: plain
@@ -1270,93 +1204,3 @@ jobs:
             -   name: Slack Notification for failed job
                 uses: ./.github/actions/job-slack-notifications
                 if: always()
-
-    positive-docker-alpine-php-82-mariadb-robot:
-        name: "[Hackathon] Positive / Docker / Alpine / PHP 8.2 / MariaDB / Robot / API"
-        if: "contains(github.event.pull_request.head.ref, 'hackathon')"
-        runs-on: ubuntu-22.04
-        env:
-            PROGRESS_TYPE: plain
-            SPRYKER_PLATFORM_IMAGE: spryker/php:8.2
-            TRAVIS: 1
-            ROBOT_TESTS_ARTIFACTS_BUCKET_REGION: eu-west-1
-            SPRYKER_CURRENT_REGION: EU
-            DYNAMIC_STORE_MODE: true
-        steps:
-            -   uses: actions/checkout@v4
-            -   name: Install packages
-                run: |
-                    sudo apt-get update
-                    sudo apt install awscli -q
-
-            -   name: Install robotframework-suite-tests folder
-                run: |
-                    cd ./data && composer require "spryker/robotframework-suite-tests:dev-master" --dev --no-interaction
-                    cp -r vendor ../vendor
-
-            -   name: Install docker-compose
-                run: |
-                    sudo curl -L "https://github.com/docker/compose/releases/download/2.12.0/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
-                    sudo chmod +x /usr/local/bin/docker-compose
-            -   name: Install Project
-                continue-on-error: true
-                run: |
-                    git clone https://github.com/spryker/docker-sdk.git ./docker
-                    docker/sdk boot deploy.ci.api.mariadb.robot.yml
-                    sudo bash -c "echo '127.0.0.1 backend-api.eu.spryker.local backend-api.us.spryker.local backend-gateway.eu.spryker.local backend-gateway.us.spryker.local backoffice.eu.spryker.local backoffice.us.spryker.local glue-backend.eu.spryker.local glue-backend.us.spryker.local glue-storefront.eu.spryker.local glue-storefront.us.spryker.local glue.eu.spryker.local glue.us.spryker.local mail.spryker.local mp.eu.spryker.local mp.us.spryker.local queue.spryker.local spryker.local swagger.spryker.local yves.eu.spryker.local yves.us.spryker.local' >> /etc/hosts"
-                    docker/sdk up -t
-                    docker/sdk cli composer dump-autoload -o -a --apcu
-                    docker/sdk testing console queue:worker:start --stop-when-empty
-                    docker/sdk console queue:worker:start --stop-when-empty
-            -   name: Run Tests
-                run: |
-                    docker/sdk exec robot-framework robot -v env:api_mp_b2b -v docker:True -v dms:true -v glue_env:http://glue.eu.spryker.local -v bapi_env:http://glue-backend.eu.spryker.local -v sapi_env:http://glue-storefront.eu.spryker.local --exclude skip-due-to-issueORskip-due-to-refactoring -d results -s robotframework.tests.api.mp_b2b.'*'.positive .
-            -   name: Upload artifacts
-                if: failure()
-                run: |
-                    AWS_DEFAULT_REGION=${{env.ROBOT_TESTS_ARTIFACTS_BUCKET_REGION}} AWS_ACCESS_KEY_ID=${{ secrets.ROBOT_TESTS_ARTIFACTS_KEY }} AWS_SECRET_ACCESS_KEY=${{ secrets.ROBOT_TESTS_ARTIFACTS_SECRET }} aws s3 cp .robot/results/log.html s3://${{vars.ROBOT_TESTS_ARTIFACTS_BUCKET}}/b2b-mp/dms-on/robot-api/${GITHUB_RUN_ID}/PHP8.2MariaDB/positive/log.html
-
-    negative-docker-alpine-php-82-mariadb-robot:
-        name: "[Hackathon] Negative / Docker / Alpine / PHP 8.2 / MariaDB / Robot / API"
-        if: "contains(github.event.pull_request.head.ref, 'hackathon')"
-        runs-on: ubuntu-22.04
-        env:
-            PROGRESS_TYPE: plain
-            SPRYKER_PLATFORM_IMAGE: spryker/php:8.2
-            TRAVIS: 1
-            ROBOT_TESTS_ARTIFACTS_BUCKET_REGION: eu-west-1
-            SPRYKER_CURRENT_REGION: EU
-            DYNAMIC_STORE_MODE: true
-        steps:
-            -   uses: actions/checkout@v4
-            -   name: Install packages
-                run: |
-                    sudo apt-get update
-                    sudo apt install awscli -q
-
-            -   name: Install robotframework-suite-tests folder
-                run: |
-                    cd ./data && composer require "spryker/robotframework-suite-tests:dev-master" --dev --no-interaction
-                    cp -r vendor ../vendor
-
-            -   name: Install docker-compose
-                run: |
-                    sudo curl -L "https://github.com/docker/compose/releases/download/2.12.0/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
-                    sudo chmod +x /usr/local/bin/docker-compose
-            -   name: Install Project
-                continue-on-error: true
-                run: |
-                    git clone https://github.com/spryker/docker-sdk.git ./docker
-                    docker/sdk boot deploy.ci.api.mariadb.robot.yml
-                    sudo bash -c "echo '127.0.0.1 backend-api.eu.spryker.local backend-api.us.spryker.local backend-gateway.eu.spryker.local backend-gateway.us.spryker.local backoffice.eu.spryker.local backoffice.us.spryker.local glue-backend.eu.spryker.local glue-backend.us.spryker.local glue-storefront.eu.spryker.local glue-storefront.us.spryker.local glue.eu.spryker.local glue.us.spryker.local mail.spryker.local mp.eu.spryker.local mp.us.spryker.local queue.spryker.local spryker.local swagger.spryker.local yves.eu.spryker.local yves.us.spryker.local' >> /etc/hosts"
-                    docker/sdk up -t
-                    docker/sdk cli composer dump-autoload -o -a --apcu
-                    docker/sdk testing console queue:worker:start --stop-when-empty
-                    docker/sdk console queue:worker:start --stop-when-empty
-            -   name: Run Tests
-                run: |
-                    docker/sdk exec robot-framework robot -v env:api_mp_b2b -v docker:True -v dms:true -v glue_env:http://glue.eu.spryker.local -v bapi_env:http://glue-backend.eu.spryker.local -v sapi_env:http://glue-storefront.eu.spryker.local --exclude skip-due-to-issueORskip-due-to-refactoring -d results -s robotframework.tests.api.mp_b2b.'*'.negative .
-            -   name: Upload artifacts
-                if: failure()
-                run: |
-                    AWS_DEFAULT_REGION=${{env.ROBOT_TESTS_ARTIFACTS_BUCKET_REGION}} AWS_ACCESS_KEY_ID=${{ secrets.ROBOT_TESTS_ARTIFACTS_KEY }} AWS_SECRET_ACCESS_KEY=${{ secrets.ROBOT_TESTS_ARTIFACTS_SECRET }} aws s3 cp .robot/results/log.html s3://${{vars.ROBOT_TESTS_ARTIFACTS_BUCKET}}/b2b-mp/dms-on/robot-api/${GITHUB_RUN_ID}/PHP8.2MariaDB/negative/log.html

--- a/.github/workflows/robot-ui-e2e-tests.yml
+++ b/.github/workflows/robot-ui-e2e-tests.yml
@@ -23,7 +23,7 @@ jobs:
                 && (contains(github.event.pull_request.labels.*.name, 'run-ui-ci')
                     || contains(github.event.pull_request.labels.*.name, 'run-latest-ci'))
             ) || github.ref == 'refs/heads/master'
-        name: "Docker / Alpine / PHP 8.3 / MariaDB / Robot / UI / Group One"
+        name: "[run-ui-ci] PHP 8.3 / MariaDB / Robot / UI / Group One"
         runs-on: ubuntu-22.04
         env:
             PROGRESS_TYPE: plain
@@ -96,7 +96,7 @@ jobs:
                 && (contains(github.event.pull_request.labels.*.name, 'run-ui-ci')
                     || contains(github.event.pull_request.labels.*.name, 'run-latest-ci'))
             ) || github.ref == 'refs/heads/master'
-        name: "Docker / Alpine / PHP 8.3 / MariaDB / Robot / UI /Group Two"
+        name: "[run-ui-ci] PHP 8.3 / MariaDB / Robot / UI /Group Two"
         runs-on: ubuntu-22.04
         env:
             PROGRESS_TYPE: plain
@@ -169,7 +169,7 @@ jobs:
                 && (contains(github.event.pull_request.labels.*.name, 'run-ui-ci')
                     || contains(github.event.pull_request.labels.*.name, 'run-latest-ci'))
             ) || github.ref == 'refs/heads/master'
-        name: "Docker / Alpine / PHP 8.3 / MariaDB / Robot / UI / Group Three"
+        name: "[run-ui-ci] PHP 8.3 / MariaDB / Robot / UI / Group Three"
         runs-on: ubuntu-22.04
         env:
             PROGRESS_TYPE: plain


### PR DESCRIPTION
#### Overview

- Ticket: https://spryker.atlassian.net/browse/CC-35775, https://spryker.atlassian.net/browse/CC-35776 + updated PR template

###### Optional

- PR Template Extension:
Extend the PR template to include [guidance on label usage](https://spryker.atlassian.net/wiki/spaces/Framework/pages/4715216905/Using+PR+labels+to+control+CI+runs+for+project+repositories).
- Cleanup of Obsolete Pipelines:
Remove obsolete ‘hackaton' jobs/pipelines from the CI configuration (called ‘Positive’ and 'Negative’).
Merge duplicated Robot / API jobs
Current state: 3 robot API jobs are executed
1) PHP 8.2 / MariaDB / Robot / Dynamic Store OFF
2) PHP 8.3 / PostgreSQL / Robot / API
3) PHP 8.3 / MariaDB / Robot / API
Desired state: merge 1) and 2) jobs, so we have
1) PHP 8.2 / PostgreSQL / Robot / API / Dynamic Store OFF
2) PHP 8.3 / MariaDB / Robot / API
- Pipeline/Job Naming Convention Update:
Revise the naming of pipelines and jobs to clearly reflect their relation to CI labels.
For example, replace verbose names such as “Docker / Alpine / PHP 8.3 / PostgreSQL / Robot / API” with a more concise format like:
"[run-api-ci] / PHP 8.3 / PostgreSQL / Robot / API".
Use lower-level labels for renaming (e.g., run-static-ci, run-ui-ci, etc.), not high-level (run-latest-ci , run-compatibility-ci) to enhance clarity.

- [x] Check api label
- [x] Check functional label
- [ ] Check ui label
- [ ] Check latest label
- [ ] Check compatibility label
- [ ] Check latest + compatibility labels
- [ ] Check master
