### PR TITLE
ACP-5234: added import glossary during normal deployment

### DIFF
--- a/config/install/production.yml
+++ b/config/install/production.yml
@@ -30,6 +30,9 @@ sections:
             command: 'vendor/bin/console queue:setup'
         scheduler-setup:
             command: 'vendor/bin/console scheduler:setup -vvv --no-ansi'
+    data-import:
+        glossary:
+            command: 'vendor/bin/console data:import:glossary -vvv --no-ansi'
     acl:
         acl-entity-synchronize:
             command: 'vendor/bin/console acl-entity:synchronize -vvv --no-ansi'


### PR DESCRIPTION
#### Overview

- Ticket: https://spryker.atlassian.net/browse/ACP-5234

###### Optional

- Core PR: URL_HERE

###### Change log

As for ACP we are not running destructive deployment we should update glossary during normal deployment
{Relevant changes for project level go here.}

###### CI Notice
Tests do **not** run automatically on every PR.
To trigger the required test suites, please add the appropriate label(s) to your PR.
For the full list of labels and their associated tests, see our Confluence page: [CI Test Labels & Triggers](https://spryker.atlassian.net/wiki/spaces/Framework/pages/4715216905/Using+PR+labels+to+control+CI+runs+for+project+repositories)
