### PR TITLE
ACP-5234: added import glossary during normal deployment

### DIFF
--- a/config/install/EU/production.dynamic-store-off.yml
+++ b/config/install/EU/production.dynamic-store-off.yml
@@ -32,6 +32,9 @@ sections:
         scheduler-setup:
             command: "vendor/bin/console scheduler:setup -vvv --no-ansi"
             stores: true
+    data-import:
+        glossary:
+            command: 'vendor/bin/console data:import:glossary -vvv --no-ansi'
     acl:
         acl-entity-synchronize:
             command: 'vendor/bin/console acl-entity:synchronize -vvv --no-ansi'


### PR DESCRIPTION
#### Overview

- Ticket: URL_HERE

###### Optional

- Core PR:https://spryker.atlassian.net/browse/ACP-5234

###### Change log

{Relevant changes for project level go here.}

###### CI Notice
Tests do **not** run automatically on every PR.
To trigger the required test suites, please add the appropriate label(s) to your PR.
For the full list of labels and their associated tests, see our Confluence page: [CI Test Labels & Triggers](https://spryker.atlassian.net/wiki/spaces/Framework/pages/4715216905/Using+PR+labels+to+control+CI+runs+for+project+repositories)
