### PR TITLE
CC-36099 added cypress tests

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -337,7 +337,7 @@
         "spryker-sdk/phpstan-spryker": "^0.4.2",
         "spryker/architecture-sniffer": "^0.5.8",
         "spryker/code-sniffer": "^0.17.28",
-        "spryker/cypress-tests": "dev-master",
+        "spryker/cypress-tests": "dev-feature/cc-36099-tests-for-table-filters",
         "spryker/docker-chromedriver": "dev-master",
         "spryker/profiler": "^0.1.1",
         "spryker/robotframework-suite-tests": "dev-master",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "24f1502dd8b98e3d8ade02e5371ae488",
+    "content-hash": "1f2d2a287427c2ebf2c36802f45d3779",
     "packages": [
         {
             "name": "async-aws/core",
@@ -79680,19 +79680,18 @@
         },
         {
             "name": "spryker/cypress-tests",
-            "version": "dev-master",
+            "version": "dev-feature/cc-36099-tests-for-table-filters",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker/cypress-tests.git",
-                "reference": "f97200bb0ffda9f8fb4bb319fca217aea080db24"
+                "reference": "937214cdf59fb5690eeae6a07f5f991244707934"
             },
-            "default-branch": true,
             "type": "library",
             "license": [
                 "MIT"
             ],
             "description": "This repository is dedicated to housing an extensive collection of UI end-to-end tests, meticulously crafted using Cypress for Spryker applications. These tests are designed to thoroughly evaluate the user interface, ensuring that all interactions and visual elements function as intended in real-world scenarios. By leveraging Cypress's advanced browser automation capabilities, this suite provides an efficient and effective means of validating the user experience, confirming the seamless operation and aesthetic integrity of Spryker's front-end components. Our commitment to rigorous UI testing helps maintain the high standard of quality and reliability that Spryker users expect.",
-            "time": "2025-07-29T08:39:03+00:00"
+            "time": "2025-07-31T14:01:53+00:00"
         },
         {
             "name": "spryker/development",


### PR DESCRIPTION
#### Overview

- Ticket: https://spryker.atlassian.net/browse/CC-36099

###### Optional


###### Change log

{Relevant changes for project level go here.}

###### CI Notice
Tests do **not** run automatically on every PR.
To trigger the required test suites, please add the appropriate label(s) to your PR.
For the full list of labels and their associated tests, see our Confluence page: [CI Test Labels & Triggers](https://spryker.atlassian.net/wiki/spaces/Framework/pages/4715216905/Using+PR+labels+to+control+CI+runs+for+project+repositories)
