### PR TITLE
FRW-10578 Added GHA for generating and uploading API specs.

### DIFF
--- a/.github/workflows/generate-api-docs.yml
+++ b/.github/workflows/generate-api-docs.yml
@@ -1,0 +1,42 @@
+name: Generate and Publish API Specs
+
+on:
+  workflow_run:
+    # The name of the workflow to watch
+    workflows: ["B2B-MP-CI"]
+    # The event type that triggers this workflow
+    types:
+      - completed
+    # Optional but recommended: only run for the main/master branch
+    branches:
+      - main
+      - master
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  generate-and-publish:
+    if: github.event.workflow_run.conclusion == 'success'
+    name: Generate and Publish API Specs
+    runs-on: ubuntu-latest
+
+    permissions:
+      id-token: write # Required for AWS OIDC authentication
+      contents: read  # Required to check out the repository
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Generate and Publish Specs
+        uses: spryker-sdk/gha-api-spec-upload@main
+        with:
+          # --- Configure Inputs ---
+          app-type: 'b2b_marketplace'
+          deploy-file: 'deploy.ci.api.mariadb.yml'
+          s3-bucket: ${{ vars.API_UPLOAD_S3_AWS_BUCKET }}
+          aws-region: ${{ vars.API_UPLOAD_S3_AWS_REGION }}
+          aws-access-key-id: ${{ secrets.API_UPLOAD_S3_AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.API_UPLOAD_S3_AWS_SECRET_ACCESS_KEY }}


### PR DESCRIPTION
#### Overview

- Ticket: https://spryker.atlassian.net/browse/FRW-8367

###### Optional

- GitHub Action: https://github.com/spryker-sdk/gha-api-spec-upload

###### Change log

- Added a new workflow that generates and uploads OpenAPI schema specs to S3

###### CI Notice
Tests do **not** run automatically on every PR.
To trigger the required test suites, please add the appropriate label(s) to your PR.
For the full list of labels and their associated tests, see our Confluence page: [CI Test Labels & Triggers](https://spryker.atlassian.net/wiki/spaces/Framework/pages/4715216905/Using+PR+labels+to+control+CI+runs+for+project+repositories)
