### PR TITLE
ACP-5066: Algolia CMS Pages search integration

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -10803,16 +10803,16 @@
         },
         {
             "name": "spryker-shop/catalog-page",
-            "version": "1.29.0",
+            "version": "1.31.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker-shop/catalog-page.git",
-                "reference": "25aaafe06d2530278356a2cee4708c541d09a111"
+                "reference": "50fbc76eb22e9ad3c228753cc53be048a8f7018b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker-shop/catalog-page/zipball/25aaafe06d2530278356a2cee4708c541d09a111",
-                "reference": "25aaafe06d2530278356a2cee4708c541d09a111",
+                "url": "https://api.github.com/repos/spryker-shop/catalog-page/zipball/50fbc76eb22e9ad3c228753cc53be048a8f7018b",
+                "reference": "50fbc76eb22e9ad3c228753cc53be048a8f7018b",
                 "shasum": ""
             },
             "require": {
@@ -10868,9 +10868,9 @@
             ],
             "description": "CatalogPage module",
             "support": {
-                "source": "https://github.com/spryker-shop/catalog-page/tree/1.29.0"
+                "source": "https://github.com/spryker-shop/catalog-page/tree/1.31.0"
             },
-            "time": "2025-01-24T10:32:32+00:00"
+            "time": "2025-08-27T15:30:39+00:00"
         },
         {
             "name": "spryker-shop/category-image-storage-widget",
@@ -11486,20 +11486,21 @@
         },
         {
             "name": "spryker-shop/cms-search-page",
-            "version": "1.4.0",
+            "version": "1.5.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker-shop/cms-search-page.git",
-                "reference": "714de5af5c2a2a10b6d86c516e59edc5caf07fd8"
+                "reference": "65c95a32a24c1a5313aa9512b7c37e5d0a1b0a54"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker-shop/cms-search-page/zipball/714de5af5c2a2a10b6d86c516e59edc5caf07fd8",
-                "reference": "714de5af5c2a2a10b6d86c516e59edc5caf07fd8",
+                "url": "https://api.github.com/repos/spryker-shop/cms-search-page/zipball/65c95a32a24c1a5313aa9512b7c37e5d0a1b0a54",
+                "reference": "65c95a32a24c1a5313aa9512b7c37e5d0a1b0a54",
                 "shasum": ""
             },
             "require": {
                 "php": ">=8.2",
+                "spryker-shop/catalog-page": "^1.31.0",
                 "spryker-shop/shop-application": "^1.3.0",
                 "spryker-shop/shop-ui": "^1.28.0",
                 "spryker-shop/tabs-widget-extension": "^1.0.0",
@@ -11533,9 +11534,9 @@
             ],
             "description": "CmsSearchPage module",
             "support": {
-                "source": "https://github.com/spryker-shop/cms-search-page/tree/1.4.0"
+                "source": "https://github.com/spryker-shop/cms-search-page/tree/1.5.0"
             },
-            "time": "2024-11-28T15:34:10+00:00"
+            "time": "2025-08-27T15:30:39+00:00"
         },
         {
             "name": "spryker-shop/cms-slot-block-widget",
@@ -18308,16 +18309,16 @@
         },
         {
             "name": "spryker-shop/shop-ui",
-            "version": "1.96.0",
+            "version": "1.96.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker-shop/shop-ui.git",
-                "reference": "63a160bbd22e5cfc36564ef91e8996b581db1447"
+                "reference": "08b69450b89eb2cddda91628bd83a95f5264e662"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker-shop/shop-ui/zipball/63a160bbd22e5cfc36564ef91e8996b581db1447",
-                "reference": "63a160bbd22e5cfc36564ef91e8996b581db1447",
+                "url": "https://api.github.com/repos/spryker-shop/shop-ui/zipball/08b69450b89eb2cddda91628bd83a95f5264e662",
+                "reference": "08b69450b89eb2cddda91628bd83a95f5264e662",
                 "shasum": ""
             },
             "require": {
@@ -18365,9 +18366,9 @@
             ],
             "description": "ShopUi module",
             "support": {
-                "source": "https://github.com/spryker-shop/shop-ui/tree/1.96.0"
+                "source": "https://github.com/spryker-shop/shop-ui/tree/1.96.1"
             },
-            "time": "2025-08-15T10:41:41+00:00"
+            "time": "2025-08-27T15:30:39+00:00"
         },
         {
             "name": "spryker-shop/shopping-list-note-widget",
@@ -22987,24 +22988,24 @@
         },
         {
             "name": "spryker/catalog",
-            "version": "5.10.0",
+            "version": "5.11.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker/catalog.git",
-                "reference": "b358c8f367c0b240a67cfd92788f0e120522bee5"
+                "reference": "a426118525866c5333f86e8b22e22c439a6af7fb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker/catalog/zipball/b358c8f367c0b240a67cfd92788f0e120522bee5",
-                "reference": "b358c8f367c0b240a67cfd92788f0e120522bee5",
+                "url": "https://api.github.com/repos/spryker/catalog/zipball/a426118525866c5333f86e8b22e22c439a6af7fb",
+                "reference": "a426118525866c5333f86e8b22e22c439a6af7fb",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.1",
+                "php": ">=8.2",
                 "spryker/catalog-extension": "^1.0.0",
                 "spryker/kernel": "^3.30.0",
                 "spryker/search": "^6.0.0 || ^7.0.0 || ^8.0.0",
-                "spryker/search-extension": "^1.3.0",
+                "spryker/search-extension": "^1.4.0",
                 "spryker/symfony": "^3.0.0",
                 "spryker/transfer": "^3.27.0"
             },
@@ -23017,7 +23018,7 @@
                 "spryker/config": "If you want to use Elastica plugins.",
                 "spryker/elastica": "If you want to use Elastica plugins.",
                 "spryker/product-page-search": "If you want to use ProductPageSearch plugins, minimum required version: 0.1.0.",
-                "spryker/search-http": "If you want to use SearchHttp plugins."
+                "spryker/search-http": "If you want to use SearchHttp plugins (for Algolia ACP app)."
             },
             "type": "library",
             "extra": {
@@ -23036,26 +23037,26 @@
             ],
             "description": "Catalog module",
             "support": {
-                "source": "https://github.com/spryker/catalog/tree/5.10.0"
+                "source": "https://github.com/spryker/catalog/tree/5.11.0"
             },
-            "time": "2023-11-17T13:33:28+00:00"
+            "time": "2025-08-27T15:30:36+00:00"
         },
         {
             "name": "spryker/catalog-extension",
-            "version": "1.0.0",
+            "version": "1.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker/catalog-extension.git",
-                "reference": "613a20224dc13f2d3a7ab268d40d81c73b109707"
+                "reference": "cd7cec23a1867729b9bf753fd103b5f43e8d20d6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker/catalog-extension/zipball/613a20224dc13f2d3a7ab268d40d81c73b109707",
-                "reference": "613a20224dc13f2d3a7ab268d40d81c73b109707",
+                "url": "https://api.github.com/repos/spryker/catalog-extension/zipball/cd7cec23a1867729b9bf753fd103b5f43e8d20d6",
+                "reference": "cd7cec23a1867729b9bf753fd103b5f43e8d20d6",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.0"
+                "php": ">=8.2"
             },
             "require-dev": {
                 "spryker/code-sniffer": "*"
@@ -23077,9 +23078,9 @@
             ],
             "description": "CatalogExtension module",
             "support": {
-                "source": "https://github.com/spryker/catalog-extension/tree/1.0.0"
+                "source": "https://github.com/spryker/catalog-extension/tree/1.1.0"
             },
-            "time": "2023-02-20T10:18:53+00:00"
+            "time": "2025-08-27T15:30:36+00:00"
         },
         {
             "name": "spryker/catalog-price-product-connector",
@@ -24508,30 +24509,36 @@
         },
         {
             "name": "spryker/cms",
-            "version": "7.16.0",
+            "version": "7.18.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker/cms.git",
-                "reference": "abb9b2754e40c626e75e6334878de7c37c8123c2"
+                "reference": "9624c6349f62bca41d81de5eb87ba3d3684a94b2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker/cms/zipball/abb9b2754e40c626e75e6334878de7c37c8123c2",
-                "reference": "abb9b2754e40c626e75e6334878de7c37c8123c2",
+                "url": "https://api.github.com/repos/spryker/cms/zipball/9624c6349f62bca41d81de5eb87ba3d3684a94b2",
+                "reference": "9624c6349f62bca41d81de5eb87ba3d3684a94b2",
                 "shasum": ""
             },
             "require": {
                 "php": ">=8.2",
                 "spryker/category": "^3.0.0 || ^4.0.0 || ^5.0.0",
                 "spryker/cms-extension": "^1.1.0",
+                "spryker/event": "^2.3.0",
                 "spryker/glossary": "^3.1.0",
                 "spryker/gui": "^3.48.0",
-                "spryker/kernel": "^3.30.0",
+                "spryker/kernel": "^3.76.0",
                 "spryker/locale": "^3.0.0 || ^4.0.0",
+                "spryker/log": "^3.0.0",
+                "spryker/message-broker": "^1.0.0",
+                "spryker/message-broker-extension": "^1.0.0",
                 "spryker/propel-orm": "^1.0.0",
+                "spryker/publisher-extension": "^1.0.0",
                 "spryker/store": "^1.0.0",
                 "spryker/symfony": "^3.0.0",
                 "spryker/touch": "^3.0.0 || ^4.0.0",
+                "spryker/transfer": "^3.27.0",
                 "spryker/url": "^3.5.0",
                 "spryker/util-encoding": "^2.0.0",
                 "spryker/util-text": "^1.1.0",
@@ -24544,6 +24551,7 @@
                 "spryker/event-dispatcher": "*",
                 "spryker/form": "*",
                 "spryker/propel": "*",
+                "spryker/queue": "*",
                 "spryker/router": "*",
                 "spryker/testify": "*",
                 "spryker/twig": "*",
@@ -24572,9 +24580,9 @@
             ],
             "description": "Cms module",
             "support": {
-                "source": "https://github.com/spryker/cms/tree/7.16.0"
+                "source": "https://github.com/spryker/cms/tree/7.18.0"
             },
-            "time": "2025-05-27T12:00:14+00:00"
+            "time": "2025-08-27T15:30:36+00:00"
         },
         {
             "name": "spryker/cms-block",
@@ -25746,31 +25754,31 @@
         },
         {
             "name": "spryker/cms-page-search",
-            "version": "2.7.0",
+            "version": "2.9.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker/cms-page-search.git",
-                "reference": "2dd577f3fdc0ef7258673659eb972662a282fbad"
+                "reference": "7e3f8b58a63ff939ceae6027f1afa1844bf961d5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker/cms-page-search/zipball/2dd577f3fdc0ef7258673659eb972662a282fbad",
-                "reference": "2dd577f3fdc0ef7258673659eb972662a282fbad",
+                "url": "https://api.github.com/repos/spryker/cms-page-search/zipball/7e3f8b58a63ff939ceae6027f1afa1844bf961d5",
+                "reference": "7e3f8b58a63ff939ceae6027f1afa1844bf961d5",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.1",
+                "php": ">=8.2",
                 "spryker/cms": "^7.0.0",
                 "spryker/event-behavior": "^1.10.0",
-                "spryker/kernel": "^3.30.0",
+                "spryker/kernel": "^3.77.0",
                 "spryker/locale": "^3.1.0 || ^4.0.0",
                 "spryker/propel-orm": "^1.0.0",
                 "spryker/search": "^7.0.0 || ^8.0.0",
-                "spryker/search-extension": "^1.0.0",
+                "spryker/search-extension": "^1.4.0",
                 "spryker/store": "^1.4.0",
                 "spryker/synchronization-behavior": "^1.0.0",
                 "spryker/synchronization-extension": "^1.0.0",
-                "spryker/transfer": "^3.25.0",
+                "spryker/transfer": "^3.27.0",
                 "spryker/util-encoding": "^2.0.0"
             },
             "require-dev": {
@@ -25785,6 +25793,7 @@
                 "spryker/config": "If you want to use config.",
                 "spryker/elastica": "If you want to use Elastica plugins.",
                 "spryker/event": "If you want to use Event plugins, minimum required version: 2.1.0",
+                "spryker/search-http": "If you want to use Search HTTP plugins (for Algolia ACP app).",
                 "spryker/url": "If you want to use Url plugins, minimum required version: 3.3.0"
             },
             "type": "library",
@@ -25804,9 +25813,9 @@
             ],
             "description": "CmsPageSearch module",
             "support": {
-                "source": "https://github.com/spryker/cms-page-search/tree/2.7.0"
+                "source": "https://github.com/spryker/cms-page-search/tree/2.9.0"
             },
-            "time": "2024-05-06T12:15:28+00:00"
+            "time": "2025-08-27T15:30:36+00:00"
         },
         {
             "name": "spryker/cms-pages-content-banners-resource-relationship",
@@ -62080,20 +62089,20 @@
         },
         {
             "name": "spryker/search-extension",
-            "version": "1.3.0",
+            "version": "1.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker/search-extension.git",
-                "reference": "149f7e2e993067718af9170eabc45fb58a255fda"
+                "reference": "79bfa0787182d9c187fc0eb4ad4a33a7792eeae3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker/search-extension/zipball/149f7e2e993067718af9170eabc45fb58a255fda",
-                "reference": "149f7e2e993067718af9170eabc45fb58a255fda",
+                "url": "https://api.github.com/repos/spryker/search-extension/zipball/79bfa0787182d9c187fc0eb4ad4a33a7792eeae3",
+                "reference": "79bfa0787182d9c187fc0eb4ad4a33a7792eeae3",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.0"
+                "php": ">=8.2"
             },
             "require-dev": {
                 "spryker/code-sniffer": "*",
@@ -62120,27 +62129,26 @@
             ],
             "description": "SearchExtension module",
             "support": {
-                "source": "https://github.com/spryker/search-extension/tree/1.3.0"
+                "source": "https://github.com/spryker/search-extension/tree/1.4.0"
             },
-            "time": "2023-09-11T11:36:57+00:00"
+            "time": "2025-08-27T15:30:36+00:00"
         },
         {
             "name": "spryker/search-http",
-            "version": "0.5.4",
+            "version": "0.5.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker/search-http.git",
-                "reference": "003d61769eebccddf0536a1cb33a15929457de3d"
+                "reference": "4e928d72669b1652dc08a274f639ec378cff5e0f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker/search-http/zipball/003d61769eebccddf0536a1cb33a15929457de3d",
-                "reference": "003d61769eebccddf0536a1cb33a15929457de3d",
+                "url": "https://api.github.com/repos/spryker/search-http/zipball/4e928d72669b1652dc08a274f639ec378cff5e0f",
+                "reference": "4e928d72669b1652dc08a274f639ec378cff5e0f",
                 "shasum": ""
             },
             "require": {
                 "php": ">=8.2",
-                "spryker/catalog-extension": "^1.0.0",
                 "spryker/category-storage": "^2.0.0",
                 "spryker/customer": "^7.61.0",
                 "spryker/kernel": "^3.30.0",
@@ -62151,7 +62159,7 @@
                 "spryker/money": "^2.8.0",
                 "spryker/product-storage": "^1.36.0",
                 "spryker/propel-orm": "^1.16.0",
-                "spryker/search-extension": "^1.3.0",
+                "spryker/search-extension": "^1.4.0",
                 "spryker/storage": "^3.4.0",
                 "spryker/store": "^1.19.0",
                 "spryker/synchronization": "^1.18.0",
@@ -62192,9 +62200,9 @@
             ],
             "description": "SearchHttp module",
             "support": {
-                "source": "https://github.com/spryker/search-http/tree/0.5.4"
+                "source": "https://github.com/spryker/search-http/tree/0.5.6"
             },
-            "time": "2025-07-17T13:04:54+00:00"
+            "time": "2025-08-27T15:30:36+00:00"
         },
         {
             "name": "spryker/secrets-manager",

--- a/config/Shared/config_default.php
+++ b/config/Shared/config_default.php
@@ -10,9 +10,12 @@ use Generated\Shared\Transfer\AssetDeletedTransfer;
 use Generated\Shared\Transfer\AssetUpdatedTransfer;
 use Generated\Shared\Transfer\CancelPaymentTransfer;
 use Generated\Shared\Transfer\CapturePaymentTransfer;
+use Generated\Shared\Transfer\CmsPagePublishedTransfer;
+use Generated\Shared\Transfer\CmsPageUnpublishedTransfer;
 use Generated\Shared\Transfer\ConfigureTaxAppTransfer;
 use Generated\Shared\Transfer\DeletePaymentMethodTransfer;
 use Generated\Shared\Transfer\DeleteTaxAppTransfer;
+use Generated\Shared\Transfer\InitializeCmsPageExportTransfer;
 use Generated\Shared\Transfer\InitializeProductExportTransfer;
 use Generated\Shared\Transfer\MerchantAppOnboardingStatusChangedTransfer;
 use Generated\Shared\Transfer\OrderStatusChangedTransfer;
@@ -56,6 +59,7 @@ use Spryker\Shared\Application\Log\Config\SprykerLoggerConfig;
 use Spryker\Shared\AvailabilityNotification\AvailabilityNotificationConstants;
 use Spryker\Shared\CartsRestApi\CartsRestApiConstants;
 use Spryker\Shared\Category\CategoryConstants;
+use Spryker\Shared\Cms\CmsConstants;
 use Spryker\Shared\CmsGui\CmsGuiConstants;
 use Spryker\Shared\Customer\CustomerConstants;
 use Spryker\Shared\DocumentationGeneratorRestApi\DocumentationGeneratorRestApiConstants;
@@ -855,6 +859,7 @@ $config[SearchHttpConstants::TENANT_IDENTIFIER]
     = $config[PaymentConstants::TENANT_IDENTIFIER]
     = $config[AppCatalogGuiConstants::TENANT_IDENTIFIER]
     = $config[TaxAppConstants::TENANT_IDENTIFIER]
+    = $config[CmsConstants::TENANT_IDENTIFIER]
     = getenv('SPRYKER_TENANT_IDENTIFIER') ?: '';
 
 $config[MessageBrokerConstants::MESSAGE_TO_CHANNEL_MAP] =
@@ -893,6 +898,9 @@ $config[MessageBrokerAwsConstants::MESSAGE_TO_CHANNEL_MAP] = [
     SubmitPaymentTaxInvoiceTransfer::class => 'payment-tax-invoice-commands',
     ReadyForMerchantAppOnboardingTransfer::class => 'merchant-app-events',
     MerchantAppOnboardingStatusChangedTransfer::class => 'merchant-app-events',
+    CmsPagePublishedTransfer::class => 'cms-page-events',
+    CmsPageUnpublishedTransfer::class => 'cms-page-events',
+    InitializeCmsPageExportTransfer::class => 'search-commands',
 ];
 
 $config[MessageBrokerConstants::CHANNEL_TO_RECEIVER_TRANSPORT_MAP] = [
@@ -909,10 +917,12 @@ $config[MessageBrokerConstants::CHANNEL_TO_RECEIVER_TRANSPORT_MAP] = [
 ];
 
 $config[MessageBrokerConstants::CHANNEL_TO_SENDER_TRANSPORT_MAP] = [
+    'cms-page-events' => MessageBrokerAwsConfig::HTTP_CHANNEL_TRANSPORT,
     'payment-commands' => MessageBrokerAwsConfig::HTTP_CHANNEL_TRANSPORT,
     'product-events' => MessageBrokerAwsConfig::HTTP_CHANNEL_TRANSPORT,
     'order-events' => MessageBrokerAwsConfig::HTTP_CHANNEL_TRANSPORT,
     'payment-tax-invoice-commands' => MessageBrokerAwsConfig::HTTP_CHANNEL_TRANSPORT,
+    'search-entity-events' => MessageBrokerAwsConfig::HTTP_CHANNEL_TRANSPORT,
 ];
 
 // -------------------------------- ACP AWS --------------------------------------

--- a/src/Pyz/Client/Catalog/CatalogDependencyProvider.php
+++ b/src/Pyz/Client/Catalog/CatalogDependencyProvider.php
@@ -28,6 +28,7 @@ use Spryker\Client\CatalogPriceProductConnector\Plugin\ProductPriceQueryExpander
 use Spryker\Client\CategoryStorage\Plugin\Catalog\ResultFormatter\CategorySuggestionsSearchHttpResultFormatterPlugin;
 use Spryker\Client\CategoryStorage\Plugin\Catalog\ResultFormatter\CategoryTreeFilterSearchHttpResultFormatterPlugin;
 use Spryker\Client\CategoryStorage\Plugin\Elasticsearch\ResultFormatter\CategoryTreeFilterPageSearchResultFormatterPlugin;
+use Spryker\Client\CmsPageSearch\Plugin\Search\SearchHttp\ResultFormatter\CmsPageSuggestionsSearchHttpResultFormatterPlugin;
 use Spryker\Client\CustomerCatalog\Plugin\Search\ProductListQueryExpanderPlugin as CustomerCatalogProductListQueryExpanderPlugin;
 use Spryker\Client\MerchantProductOfferSearch\Plugin\Search\MerchantReferenceQueryExpanderPlugin;
 use Spryker\Client\MerchantProductSearch\Plugin\Search\MerchantReferenceQueryExpanderPlugin as MerchantProductReferenceQueryExpanderPlugin;
@@ -291,6 +292,19 @@ class CatalogDependencyProvider extends SprykerCatalogDependencyProvider
                     new ProductSuggestionSearchHttpResultFormatterPlugin(),
                 ),
                 new CategorySuggestionsSearchHttpResultFormatterPlugin(),
+                new CmsPageSuggestionsSearchHttpResultFormatterPlugin(),
+            ],
+        ];
+    }
+
+    /**
+     * @return array<string, array<\Spryker\Client\SearchExtension\Dependency\Plugin\QueryExpanderPluginInterface>>
+     */
+    protected function createCatalogSearchCountQueryExpanderPluginVariants(): array
+    {
+        return [
+            SearchHttpConfig::TYPE_SEARCH_HTTP => [
+                new ProductPriceSearchHttpQueryExpanderPlugin(),
             ],
         ];
     }

--- a/src/Pyz/Client/CmsPageSearch/CmsPageSearchDependencyProvider.php
+++ b/src/Pyz/Client/CmsPageSearch/CmsPageSearchDependencyProvider.php
@@ -9,16 +9,28 @@ declare(strict_types = 1);
 
 namespace Pyz\Client\CmsPageSearch;
 
+use Generated\Shared\Transfer\SearchContextTransfer;
+use Spryker\Client\CmsPageSearch\CmsPageSearchConfig;
 use Spryker\Client\CmsPageSearch\CmsPageSearchDependencyProvider as SprykerCmsPageSearchDependencyProvider;
+use Spryker\Client\CmsPageSearch\Plugin\Elasticsearch\Query\CmsPageSearchQueryPlugin;
 use Spryker\Client\CmsPageSearch\Plugin\Elasticsearch\QueryExpander\PaginatedCmsPageQueryExpanderPlugin;
 use Spryker\Client\CmsPageSearch\Plugin\Elasticsearch\QueryExpander\SortedCmsPageQueryExpanderPlugin;
 use Spryker\Client\CmsPageSearch\Plugin\Elasticsearch\ResultFormatter\PaginatedCmsPageResultFormatterPlugin;
 use Spryker\Client\CmsPageSearch\Plugin\Elasticsearch\ResultFormatter\RawCmsPageSearchResultFormatterPlugin;
 use Spryker\Client\CmsPageSearch\Plugin\Elasticsearch\ResultFormatter\SortedCmsPageSearchResultFormatterPlugin;
+use Spryker\Client\CmsPageSearch\Plugin\Elasticsearch\SearchResultCount\SearchElasticSearchResultCountPlugin;
+use Spryker\Client\CmsPageSearch\Plugin\Search\SearchHttp\ResultFormatter\CmsPageSearchHttpResultFormatterPlugin;
+use Spryker\Client\CmsPageSearch\Plugin\Search\SearchHttp\ResultFormatter\CmsPageSortSearchHttpResultFormatterPlugin;
 use Spryker\Client\SearchElasticsearch\Plugin\QueryExpander\IsActiveInDateRangeQueryExpanderPlugin;
 use Spryker\Client\SearchElasticsearch\Plugin\QueryExpander\IsActiveQueryExpanderPlugin;
 use Spryker\Client\SearchElasticsearch\Plugin\QueryExpander\LocalizedQueryExpanderPlugin;
 use Spryker\Client\SearchElasticsearch\Plugin\QueryExpander\StoreQueryExpanderPlugin;
+use Spryker\Client\SearchHttp\Plugin\Catalog\Query\SearchHttpQueryPlugin;
+use Spryker\Client\SearchHttp\Plugin\Catalog\QueryExpander\BasicSearchHttpQueryExpanderPlugin;
+use Spryker\Client\SearchHttp\Plugin\Catalog\QueryExpander\FacetSearchHttpQueryExpanderPlugin;
+use Spryker\Client\SearchHttp\Plugin\Catalog\ResultFormatter\FacetSearchHttpResultFormatterPlugin;
+use Spryker\Client\SearchHttp\Plugin\Catalog\ResultFormatter\PaginationSearchHttpResultFormatterPlugin;
+use Spryker\Client\SearchHttp\Plugin\Search\SearchHttpSearchResultCountPlugin;
 
 class CmsPageSearchDependencyProvider extends SprykerCmsPageSearchDependencyProvider
 {
@@ -61,6 +73,58 @@ class CmsPageSearchDependencyProvider extends SprykerCmsPageSearchDependencyProv
             new LocalizedQueryExpanderPlugin(),
             new IsActiveQueryExpanderPlugin(),
             new IsActiveInDateRangeQueryExpanderPlugin(),
+        ];
+    }
+
+    /**
+     * @return array<\Spryker\Client\SearchExtension\Dependency\Plugin\QueryExpanderPluginInterface>
+     */
+    protected function getCmsPageHttpSearchQueryExpanderPlugins(): array
+    {
+        return [
+            new BasicSearchHttpQueryExpanderPlugin(),
+            new FacetSearchHttpQueryExpanderPlugin(),
+        ];
+    }
+
+    /**
+     * @return array<\Spryker\Client\SearchExtension\Dependency\Plugin\ResultFormatterPluginInterface>
+     */
+    protected function getCmsPageHttpSearchResultFormatterPlugins(): array
+    {
+        return [
+            new PaginationSearchHttpResultFormatterPlugin(),
+            new CmsPageSortSearchHttpResultFormatterPlugin(),
+            new CmsPageSearchHttpResultFormatterPlugin(),
+            new FacetSearchHttpResultFormatterPlugin(),
+        ];
+    }
+
+    /**
+     * @return array<\Spryker\Client\SearchExtension\Dependency\Plugin\QueryInterface>
+     */
+    protected function getCmsPageSearchQueryPlugins(): array
+    {
+        /** @var array<\Spryker\Client\SearchExtension\Dependency\Plugin\QueryInterface> $plugins */
+        $plugins = [
+            new SearchHttpQueryPlugin(
+                (new SearchContextTransfer())
+                    ->setSourceIdentifier(CmsPageSearchConfig::SOURCE_IDENTIFIER_CMS_PAGE),
+            ),
+            new CmsPageSearchQueryPlugin(),
+        ];
+
+        return $plugins;
+    }
+
+    /**
+     * @return array<\Spryker\Client\SearchExtension\Dependency\Plugin\SearchResultCountPluginInterface>
+     */
+    protected function getCmsPageSearchResultCountPlugins(): array
+    {
+        return [
+            CmsPageSearchConfig::SEARCH_STRATEGY_SEARCH_HTTP => new SearchHttpSearchResultCountPlugin(),
+            CmsPageSearchConfig::SEARCH_STRATEGY_ELASTICSEARCH => new SearchElasticSearchResultCountPlugin(),
         ];
     }
 }

--- a/src/Pyz/Zed/MessageBroker/MessageBrokerDependencyProvider.php
+++ b/src/Pyz/Zed/MessageBroker/MessageBrokerDependencyProvider.php
@@ -10,6 +10,7 @@ declare(strict_types = 1);
 namespace Pyz\Zed\MessageBroker;
 
 use Spryker\Zed\Asset\Communication\Plugin\MessageBroker\AssetMessageHandlerPlugin;
+use Spryker\Zed\Cms\Communication\Plugin\MessageBroker\CmsPageMessageHandlerPlugin;
 use Spryker\Zed\KernelApp\Communication\Plugin\MessageBroker\ActiveAppFilterMessageChannelPlugin;
 use Spryker\Zed\KernelApp\Communication\Plugin\MessageBroker\AppConfigMessageHandlerPlugin;
 use Spryker\Zed\MerchantApp\Communication\Plugin\MessageBroker\MerchantAppOnboardingMessageHandlerPlugin;
@@ -73,6 +74,7 @@ class MessageBrokerDependencyProvider extends SprykerMessageBrokerDependencyProv
             new PaymentOperationsMessageHandlerPlugin(),
             new SalesPaymentDetailMessageHandlerPlugin(),
             new MerchantAppOnboardingMessageHandlerPlugin(),
+            new CmsPageMessageHandlerPlugin(),
         ];
     }
 

--- a/src/Pyz/Zed/Publisher/PublisherDependencyProvider.php
+++ b/src/Pyz/Zed/Publisher/PublisherDependencyProvider.php
@@ -42,6 +42,8 @@ use Spryker\Zed\CategoryStorage\Communication\Plugin\Publisher\CategoryTree\Cate
 use Spryker\Zed\CategoryStorage\Communication\Plugin\Publisher\CategoryTree\CategoryTreeWriteForPublishingPublisherPlugin;
 use Spryker\Zed\CategoryStorage\Communication\Plugin\Publisher\CategoryTreePublisherTriggerPlugin;
 use Spryker\Zed\CategoryStorage\Communication\Plugin\Publisher\ParentWritePublisherPlugin;
+use Spryker\Zed\Cms\Communication\Plugin\Publisher\CmsPageUpdateMessageBrokerPublisherPlugin;
+use Spryker\Zed\Cms\Communication\Plugin\Publisher\CmsPageVersionPublishedMessageBrokerPublisherPlugin;
 use Spryker\Zed\CustomerAccessStorage\Communication\Plugin\Publisher\CustomerAccessPublisherTriggerPlugin;
 use Spryker\Zed\CustomerStorage\Communication\Plugin\Publisher\Customer\CustomerInvalidatedWritePublisherPlugin;
 use Spryker\Zed\FileManagerStorage\Communication\Plugin\Publisher\FileManagerPublisherTriggerPlugin;
@@ -198,6 +200,7 @@ class PublisherDependencyProvider extends SprykerPublisherDependencyProvider
             $this->getProductOfferAvailabilityStoragePlugins(),
             $this->getTaxAppPlugins(),
             $this->getProductStoragePlugins(),
+            $this->getCmsPageMessageBrokerPlugins(),
         );
     }
 
@@ -650,6 +653,17 @@ class PublisherDependencyProvider extends SprykerPublisherDependencyProvider
     {
         return [
             new ProductLocalizedAttributesProductAbstractWritePublisherPlugin(),
+        ];
+    }
+
+    /**
+     * @return array<\Spryker\Zed\PublisherExtension\Dependency\Plugin\PublisherPluginInterface>
+     */
+    protected function getCmsPageMessageBrokerPlugins(): array
+    {
+        return [
+            new CmsPageVersionPublishedMessageBrokerPublisherPlugin(),
+            new CmsPageUpdateMessageBrokerPublisherPlugin(),
         ];
     }
 }


### PR DESCRIPTION
#### Overview

- Ticket: https://spryker.atlassian.net/browse/ACP-5066

###### Optional

- Core PRs:
https://github.com/spryker/spryker/pull/11710
https://github.com/spryker/spryker-shop/pull/2689

###### Change log

- MessageBroker configuration for new message types, + message handler CmsPageMessageHandlerPlugin.
- new plugins for Catalog and SearchHttp required for CMS pages.
- new plugins for CmsPageSearch to support different search adapters (ES or SearchHttp).
- new Publisher plugins to publish CMS pages to MessageBroker.

###### CI Notice
Tests do **not** run automatically on every PR.
To trigger the required test suites, please add the appropriate label(s) to your PR.
For the full list of labels and their associated tests, see our Confluence page: [CI Test Labels & Triggers](https://spryker.atlassian.net/wiki/spaces/Framework/pages/4715216905/Using+PR+labels+to+control+CI+runs+for+project+repositories)
