### PR TITLE
Enable gzip and brotli compression for all responses in deploy files

### DIFF
--- a/deploy.aop-b2b-testing.yml
+++ b/deploy.aop-b2b-testing.yml
@@ -88,7 +88,10 @@ assets:
     mode: production
     compression:
         brotli:
-            static: on
+            static: true
+            level: 5
+        gzip:
+            static: true
             level: 5
 
 regions:

--- a/deploy.aop-consultant-b2c.yml
+++ b/deploy.aop-consultant-b2c.yml
@@ -92,7 +92,10 @@ assets:
     mode: production
     compression:
         brotli:
-            static: on
+            static: true
+            level: 5
+        gzip:
+            static: true
             level: 5
 
 regions:

--- a/deploy.aop-demoshop-b2b.yml
+++ b/deploy.aop-demoshop-b2b.yml
@@ -88,7 +88,10 @@ assets:
     mode: production
     compression:
         brotli:
-            static: on
+            static: true
+            level: 5
+        gzip:
+            static: true
             level: 5
 
 regions:

--- a/deploy.aws-env-template.yml
+++ b/deploy.aws-env-template.yml
@@ -68,7 +68,10 @@ assets:
     mode: production
     compression:
         brotli:
-            static: on
+            static: true
+            level: 5
+        gzip:
+            static: true
             level: 5
 
 regions:

--- a/deploy.scos2-b2bmp.yml
+++ b/deploy.scos2-b2bmp.yml
@@ -32,7 +32,10 @@ assets:
     mode: production
     compression:
         brotli:
-            static: on
+            static: true
+            level: 5
+        gzip:
+            static: true
             level: 5
 regions:
     EU:

--- a/deploy.scos2-b2bmpperf.yml
+++ b/deploy.scos2-b2bmpperf.yml
@@ -33,7 +33,10 @@ assets:
     mode: production
     compression:
         brotli:
-            static: on
+            static: true
+            level: 5
+        gzip:
+            static: true
             level: 5
 regions:
     EU:

--- a/deploy.spryker-b2bmp.yml
+++ b/deploy.spryker-b2bmp.yml
@@ -57,7 +57,8 @@ assets:
     mode: production
     compression:
         brotli:
-            static: only
+            static: true
+            level: 5
         gzip:
             static: true
             level: 5

--- a/deploy.spryker-mp-b2b.yml
+++ b/deploy.spryker-mp-b2b.yml
@@ -72,7 +72,10 @@ assets:
     mode: production
     compression:
         brotli:
-            static: on
+            static: true
+            level: 5
+        gzip:
+            static: true
             level: 5
 
 regions:

--- a/deploy.spryker-mpb2bs.yml
+++ b/deploy.spryker-mpb2bs.yml
@@ -37,7 +37,10 @@ assets:
     mode: production
     compression:
         brotli:
-            static: on
+            static: true
+            level: 5
+        gzip:
+            static: true
             level: 5
 
 regions:

--- a/deploy.spryker-scos.yml
+++ b/deploy.spryker-scos.yml
@@ -81,7 +81,10 @@ assets:
     mode: production
     compression:
         brotli:
-            static: on
+            static: true
+            level: 5
+        gzip:
+            static: true
             level: 5
 
 regions:

--- a/deploy.spryker-scosb2bmp.yml
+++ b/deploy.spryker-scosb2bmp.yml
@@ -43,7 +43,10 @@ assets:
     mode: production
     compression:
         brotli:
-            static: on
+            static: true
+            level: 5
+        gzip:
+            static: true
             level: 5
 
 regions:

--- a/deploy.spryker-sns.yml
+++ b/deploy.spryker-sns.yml
@@ -81,7 +81,10 @@ assets:
     mode: production
     compression:
         brotli:
-            static: on
+            static: true
+            level: 5
+        gzip:
+            static: true
             level: 5
 
 regions:

--- a/deploy.yml
+++ b/deploy.yml
@@ -33,7 +33,10 @@ assets:
     mode: production
     compression:
         brotli:
-            static: on
+            static: true
+            level: 5
+        gzip:
+            static: true
             level: 5
 
 regions:


### PR DESCRIPTION
Enable both gzip and brotli with static: true in all non-dev deploy files to ensure on-the-fly compression of dynamic responses (HTML, JSON, API) in addition to pre-compressed static assets.

Previously most deploy files only had brotli configured, and deploy.spryker-b2bmp.yml had brotli set to static: only which disabled on-the-fly compression for dynamic content. Without gzip enabled, clients or CDNs that only send Accept-Encoding: gzip received uncompressed responses from the frontend container.

#### Overview

- Ticket: URL_HERE

###### Optional

- Core PR: URL_HERE

###### Change log

{Relevant changes for project level go here.}

###### CI Notice
**Additional tests** can be triggered by adding labels:
- `run-compatibility-ci` runs compatibility tests (PHP 8.3 / PostgreSQL / Debian / Prefer Lowest / Dynamic Store OFF):
    - Codeception / Acceptance & API
    - Codeception / Functional Tests
    - Robot / API
    - Robot / UI
    - Cypress / UI
