### PR TITLE
CC-37258: Open redirect fix in product comparison

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -134,6 +134,7 @@
         "spryker-shop/cms-content-widget-product-set-connector": "^1.4.0",
         "spryker-shop/date-time-configurator-page-example": "^0.5.6",
         "spryker-shop/traceable-event-widget": "^1.1.0",
+        "spryker-shop/product-comparison-page": "^1.0.1",
         "spryker/agent-auth-rest-api": "^1.2.0",
         "spryker/agent-dashboard-merchant-portal-gui": "^2.0.0",
         "spryker/agent-security-blocker-merchant-portal-gui": "^1.1.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "436005095f0dfa15631867bf7f841f8f",
+    "content-hash": "eea23fe499ab6681694d390f4756e510",
     "packages": [
         {
             "name": "algolia/algoliasearch-client-php",
@@ -19006,6 +19006,58 @@
                 "source": "https://github.com/spryker-shop/product-category-widget/tree/1.9.0"
             },
             "time": "2026-03-06T14:41:13+00:00"
+        },
+        {
+            "name": "spryker-shop/product-comparison-page",
+            "version": "1.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/spryker-shop/product-comparison-page.git",
+                "reference": "b05b640208734e05812248f16e3d2ee99c46e39b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/spryker-shop/product-comparison-page/zipball/b05b640208734e05812248f16e3d2ee99c46e39b",
+                "reference": "b05b640208734e05812248f16e3d2ee99c46e39b",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.3",
+                "spryker-shop/shop-application": "^1.0.0",
+                "spryker-shop/shop-ui": "^1.73.0",
+                "spryker/kernel": "^3.52.0",
+                "spryker/product-storage": "^1.29.0",
+                "spryker/symfony": "^3.0.0",
+                "spryker/transfer": "^3.27.0"
+            },
+            "require-dev": {
+                "spryker/code-sniffer": "*",
+                "spryker/router": "*"
+            },
+            "suggest": {
+                "spryker/router": "Use this module if you want use the RouterProviderPlugin.",
+                "spryker/silex": "Use this module when using plugins that need Silex dependencies."
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "SprykerShop\\": "src/SprykerShop/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "proprietary"
+            ],
+            "description": "ProductComparisonPage module",
+            "support": {
+                "source": "https://github.com/spryker-shop/product-comparison-page/tree/1.0.1"
+            },
+            "time": "2026-03-06T13:00:58+00:00"
         },
         {
             "name": "spryker-shop/product-configuration-cart-widget",


### PR DESCRIPTION
#### Overview

- Ticket: https://spryker.atlassian.net/browse/CC-37258

###### Change log

- Added package: `spryker-shop/product-comparison-page: ^1.0.1`
- No feature packages updated
- No project changes applied

###### CI Notice
**Additional tests** can be triggered by adding labels:
- `run-compatibility-ci` runs compatibility tests (PHP 8.3 / PostgreSQL / Debian / Prefer Lowest / Dynamic Store OFF):
    - Codeception / Acceptance & API
    - Codeception / Functional Tests
    - Robot / API
    - Robot / UI
    - Cypress / UI