### PR TITLE
CC-37782: update `ai-dev` to 0.4.0 and integrate new console commands

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -376,7 +376,7 @@
         "phpstan/phpstan": "2.1.39",
         "phpunit/phpunit": "^12.5.14",
         "spryker-feature/development-tools": "^202602.0",
-        "spryker-sdk/ai-dev": "^0.2.2",
+        "spryker-sdk/ai-dev": "^0.4.0",
         "spryker-sdk/evaluator": "^0.3.4",
         "spryker-sdk/phpstan-spryker": "^0.5.1",
         "spryker/architecture-sniffer": "^0.5.9",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "e46ff58a0badd45a6a2956c0caa4e6a1",
+    "content-hash": "10c3ebf2ecc2760e469d08cabbe892b5",
     "packages": [
         {
             "name": "algolia/algoliasearch-client-php",
@@ -90136,22 +90136,23 @@
         },
         {
             "name": "spryker-sdk/ai-dev",
-            "version": "0.2.2",
+            "version": "0.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker-sdk/ai-dev.git",
-                "reference": "6460a86836e29eb8f67aeaaf46b4120578f627ad"
+                "reference": "f3609e038080360ff7b1fdd3607871f91dd9b9d2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker-sdk/ai-dev/zipball/6460a86836e29eb8f67aeaaf46b4120578f627ad",
-                "reference": "6460a86836e29eb8f67aeaaf46b4120578f627ad",
+                "url": "https://api.github.com/repos/spryker-sdk/ai-dev/zipball/f3609e038080360ff7b1fdd3607871f91dd9b9d2",
+                "reference": "f3609e038080360ff7b1fdd3607871f91dd9b9d2",
                 "shasum": ""
             },
             "require": {
                 "nikic/php-parser": ">=5.0",
                 "php": ">=8.3",
                 "php-mcp/server": "^3.3",
+                "spryker/csv": "^3.0",
                 "spryker/guzzle": ">=2.0.0",
                 "spryker/kernel": ">=3.30.0",
                 "spryker/module-finder": ">=1.0.0",
@@ -90163,9 +90164,10 @@
             },
             "require-dev": {
                 "phpstan/phpstan": ">=1.12.29",
-                "spryker-sdk/phpstan-spryker": ">=0.4.3",
+                "spryker-sdk/phpstan-spryker": ">=0.5.1",
                 "spryker/code-sniffer": ">=0.17.30",
-                "spryker/development": "*"
+                "spryker/development": "*",
+                "spryker/testify": "*"
             },
             "type": "library",
             "extra": {
@@ -90185,9 +90187,9 @@
             "description": "AiDev module",
             "support": {
                 "issues": "https://github.com/spryker-sdk/ai-dev/issues",
-                "source": "https://github.com/spryker-sdk/ai-dev/tree/0.2.2"
+                "source": "https://github.com/spryker-sdk/ai-dev/tree/0.4.0"
             },
-            "time": "2026-01-19T15:37:25+00:00"
+            "time": "2026-04-20T05:44:45+00:00"
         },
         {
             "name": "spryker-sdk/benchmark",
@@ -91548,7 +91550,7 @@
         "ext-readline": "*",
         "ext-redis": "*"
     },
-    "platform-dev": [],
+    "platform-dev": {},
     "platform-overrides": {
         "php": "8.3.13"
     },

--- a/src/Pyz/Zed/Console/ConsoleDependencyProvider.php
+++ b/src/Pyz/Zed/Console/ConsoleDependencyProvider.php
@@ -208,7 +208,9 @@ use SprykerEco\Zed\Algolia\Communication\Console\AlgoliaEntityExportConsole;
 use SprykerEco\Zed\NewRelic\Communication\Console\RecordDeploymentConsole;
 use SprykerFeature\Zed\ProductExperienceManagement\Communication\Console\ImportJobRunConsole;
 use SprykerFeature\Zed\SelfServicePortal\SelfServicePortalConfig;
+use SprykerSdk\Zed\AiDev\Communication\Console\GenerateAgentsFileConsole;
 use SprykerSdk\Zed\AiDev\Communication\Console\GeneratePromptsConsole;
+use SprykerSdk\Zed\AiDev\Communication\Console\GenerateSkillsConsole;
 use SprykerSdk\Zed\AiDev\Communication\Console\McpServerConsole;
 use SprykerShop\Zed\DateTimeConfiguratorPageExample\Communication\Console\DateTimeProductConfiguratorBuildFrontendConsole;
 
@@ -516,6 +518,8 @@ class ConsoleDependencyProvider extends SprykerConsoleDependencyProvider
             if (class_exists(McpServerConsole::class)) {
                 $commands[] = new McpServerConsole();
                 $commands[] = new GeneratePromptsConsole();
+                $commands[] = new GenerateAgentsFileConsole();
+                $commands[] = new GenerateSkillsConsole();
             }
 
             if (class_exists(SecurityCheckerCommand::class)) {


### PR DESCRIPTION
- Update `spryker-sdk/ai-dev` to version 0.4.0 in `composer.json` and `composer.lock`
- Integrate `GenerateAgentsFileConsole` and `GenerateSkillsConsole` commands into `ConsoleDependencyProvider`

#### Overview

- Ticket: URL_HERE

###### Change log

{Relevant changes for project level go here.}

###### CI Notice
**Additional tests** can be triggered by adding labels:
- `run-compatibility-ci` runs compatibility tests (PHP 8.3 / PostgreSQL / Debian / Prefer Lowest / Dynamic Store OFF):
    - Codeception / Acceptance & API
    - Codeception / Functional Tests
    - Robot / API
    - Robot / UI
    - Cypress / UI
