### PR TITLE
CC-36089: update `spryker/zed-navigation` to 1.16.1 in `composer.lock`

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -78034,16 +78034,16 @@
         },
         {
             "name": "spryker/zed-navigation",
-            "version": "1.16.0",
+            "version": "1.16.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker/zed-navigation.git",
-                "reference": "4495ead1b2651e5c42eda515504e0025adcf37fd"
+                "reference": "fb866e2400646e65ac47001d606f9b3130e739fe"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker/zed-navigation/zipball/4495ead1b2651e5c42eda515504e0025adcf37fd",
-                "reference": "4495ead1b2651e5c42eda515504e0025adcf37fd",
+                "url": "https://api.github.com/repos/spryker/zed-navigation/zipball/fb866e2400646e65ac47001d606f9b3130e739fe",
+                "reference": "fb866e2400646e65ac47001d606f9b3130e739fe",
                 "shasum": ""
             },
             "require": {
@@ -78092,9 +78092,9 @@
             ],
             "description": "ZedNavigation module",
             "support": {
-                "source": "https://github.com/spryker/zed-navigation/tree/1.16.0"
+                "source": "https://github.com/spryker/zed-navigation/tree/1.16.1"
             },
-            "time": "2026-03-13T11:49:27+00:00"
+            "time": "2026-04-26T17:56:20+00:00"
         },
         {
             "name": "spryker/zed-navigation-extension",
@@ -92039,5 +92039,5 @@
     "platform-overrides": {
         "php": "8.3.13"
     },
-    "plugin-api-version": "2.9.0"
+    "plugin-api-version": "2.6.0"
 }

--- a/composer.lock
+++ b/composer.lock
@@ -92039,5 +92039,5 @@
     "platform-overrides": {
         "php": "8.3.13"
     },
-    "plugin-api-version": "2.6.0"
+    "plugin-api-version": "2.9.0"
 }


### PR DESCRIPTION
- chore(composer): downgrade `plugin-api-version` to 2.6.0

#### Overview

- Ticket: URL_HERE

###### Change log

{Relevant changes for project level go here.}

###### CI Notice
**Additional tests** can be triggered by adding labels:
- `run-compatibility-ci` runs compatibility tests (PHP 8.3 / PostgreSQL / Debian / Prefer Lowest / Dynamic Store OFF):
    - Codeception / Acceptance & API
    - Codeception / Functional Tests
    - Robot / API
    - Robot / UI
    - Cypress / UI
