### PR TITLE
SOL-538 integrate backoffice part for the punchout

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "spryker-eco/google-analytics": "^1.0.0",
         "spryker-eco/loggly": "^0.1.1",
         "spryker-eco/new-relic": "^2.1.0",
-        "spryker-eco/punchout-gateway": "^0.3.0",
+        "spryker-eco/punchout-gateway": "^0.4.0",
         "spryker-eco/stripe": "^1.0.1",
         "spryker-eco/vertex": "^1.2.0",
         "spryker-feature/acl": "^202604.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "248ef24510185dd9c1c60ba6549c2b0a",
+    "content-hash": "51665c7730bfd24f50e7413438eb26ed",
     "packages": [
         {
             "name": "algolia/algoliasearch-client-php",
@@ -9965,16 +9965,16 @@
         },
         {
             "name": "spryker-eco/punchout-gateway",
-            "version": "0.3.0",
+            "version": "0.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker-eco/punchout-gateway.git",
-                "reference": "dca3b3e04d6ac88d820ee1a985db917a0f1576a6"
+                "reference": "c2c0ffead62e6bd84b01d2cf3aa039dc7f5f55ad"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker-eco/punchout-gateway/zipball/dca3b3e04d6ac88d820ee1a985db917a0f1576a6",
-                "reference": "dca3b3e04d6ac88d820ee1a985db917a0f1576a6",
+                "url": "https://api.github.com/repos/spryker-eco/punchout-gateway/zipball/c2c0ffead62e6bd84b01d2cf3aa039dc7f5f55ad",
+                "reference": "c2c0ffead62e6bd84b01d2cf3aa039dc7f5f55ad",
                 "shasum": ""
             },
             "require": {
@@ -9987,7 +9987,8 @@
                 "spryker/calculation": "^4.0.0",
                 "spryker/cart": "^7.0.0",
                 "spryker/currency": "^4.0.0",
-                "spryker/customer": "^7.10.0",
+                "spryker/customer": "^7.79.0",
+                "spryker/gui": "^5.2.2",
                 "spryker/kernel": "^3.76.0",
                 "spryker/log": "^3.17.0",
                 "spryker/price": "^5.0.0",
@@ -9998,7 +9999,9 @@
                 "spryker/store": "^1.19.0",
                 "spryker/symfony": "^3.1.0",
                 "spryker/transfer": "^3.42.0",
+                "spryker/translator": "^1.0.0",
                 "spryker/util-encoding": "^2.1.1",
+                "spryker/util-text": "^1.6.0",
                 "spryker/zed-request": "^3.0.0"
             },
             "require-dev": {
@@ -10033,9 +10036,9 @@
             "description": "PunchoutGateway module",
             "support": {
                 "issues": "https://github.com/spryker-eco/punchout-gateway/issues",
-                "source": "https://github.com/spryker-eco/punchout-gateway/tree/0.3.0"
+                "source": "https://github.com/spryker-eco/punchout-gateway/tree/0.4.0"
             },
-            "time": "2026-04-27T13:04:17+00:00"
+            "time": "2026-05-27T07:47:15+00:00"
         },
         {
             "name": "spryker-eco/stripe",
@@ -38117,16 +38120,16 @@
         },
         {
             "name": "spryker/customer",
-            "version": "7.78.2",
+            "version": "7.79.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker/customer.git",
-                "reference": "7d7fc28df7ae92fa9f76d0339178d5b2fb06148a"
+                "reference": "1361933fb9d07d0d61e9b1997704d35a4281ef3f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker/customer/zipball/7d7fc28df7ae92fa9f76d0339178d5b2fb06148a",
-                "reference": "7d7fc28df7ae92fa9f76d0339178d5b2fb06148a",
+                "url": "https://api.github.com/repos/spryker/customer/zipball/1361933fb9d07d0d61e9b1997704d35a4281ef3f",
+                "reference": "1361933fb9d07d0d61e9b1997704d35a4281ef3f",
                 "shasum": ""
             },
             "require": {
@@ -38201,9 +38204,9 @@
             ],
             "description": "Customer module",
             "support": {
-                "source": "https://github.com/spryker/customer/tree/7.78.2"
+                "source": "https://github.com/spryker/customer/tree/7.79.0"
             },
-            "time": "2026-05-22T08:02:08+00:00"
+            "time": "2026-05-27T12:26:06+00:00"
         },
         {
             "name": "spryker/customer-access",

--- a/config/Zed/navigation.xml
+++ b/config/Zed/navigation.xml
@@ -735,4 +735,11 @@
         <action>index</action>
         <visible>1</visible>
     </configuration-management>
+    <punchout-gateway>
+        <label>Punchout Connections</label>
+        <bundle>punchout-gateway</bundle>
+        <controller>list</controller>
+        <action>index</action>
+        <visible>1</visible>
+    </punchout-gateway>
 </config>


### PR DESCRIPTION
#### Overview

- Ticket: https://spryker.atlassian.net/browse/SOL-538

###### Change log

Integrate PunchOut Gateway Back Office functionality

###### CI Notice
**Additional tests** can be triggered by adding labels:
- `run-compatibility-ci` runs compatibility tests (PHP 8.3 / PostgreSQL / Debian / Prefer Lowest / Dynamic Store OFF):
    - Codeception / Acceptance & API
    - Codeception / Functional Tests
    - Robot / API
    - Robot / UI
    - Cypress / UI
