### PR TITLE
Updated redis

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -66610,16 +66610,16 @@
         },
         {
             "name": "spryker/redis",
-            "version": "2.11.1",
+            "version": "2.12.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker/redis.git",
-                "reference": "5c24b784191eda57c30eeea9386941c528ff53b0"
+                "reference": "512abd804f5d69cd6c45e974ed552798689f7a50"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker/redis/zipball/5c24b784191eda57c30eeea9386941c528ff53b0",
-                "reference": "5c24b784191eda57c30eeea9386941c528ff53b0",
+                "url": "https://api.github.com/repos/spryker/redis/zipball/512abd804f5d69cd6c45e974ed552798689f7a50",
+                "reference": "512abd804f5d69cd6c45e974ed552798689f7a50",
                 "shasum": ""
             },
             "require": {
@@ -66657,9 +66657,9 @@
             ],
             "description": "Redis module",
             "support": {
-                "source": "https://github.com/spryker/redis/tree/2.11.1"
+                "source": "https://github.com/spryker/redis/tree/2.12.0"
             },
-            "time": "2026-02-17T13:08:22+00:00"
+            "time": "2026-06-04T10:18:04+00:00"
         },
         {
             "name": "spryker/refund",
@@ -92933,9 +92933,9 @@
         "ext-readline": "*",
         "ext-redis": "*"
     },
-    "platform-dev": {},
+    "platform-dev": [],
     "platform-overrides": {
         "php": "8.3.13"
     },
-    "plugin-api-version": "2.9.0"
+    "plugin-api-version": "2.6.0"
 }


### PR DESCRIPTION
#### Overview

- Ticket: https://spryker.atlassian.net/browse/CC-39072

###### Change log

{Relevant changes for project level go here.}

###### CI Notice
**Additional tests** can be triggered by adding labels:
- `run-compatibility-ci` runs compatibility tests (PHP 8.3 / PostgreSQL / Debian / Prefer Lowest / Dynamic Store OFF):
    - Codeception / Acceptance & API
    - Codeception / Functional Tests
    - Robot / API
    - Robot / UI
    - Cypress / UI
