### PR TITLE
mute email  domain 'acme' to avoid 500 on remote env email stmp calls

### DIFF
--- a/src/Pyz/Zed/SymfonyMailer/Business/SymfonyMailerBusinessFactory.php
+++ b/src/Pyz/Zed/SymfonyMailer/Business/SymfonyMailerBusinessFactory.php
@@ -1,0 +1,29 @@
+<?php
+
+/**
+ * This file is part of the Spryker Commerce OS.
+ * For full license information, please view the LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types = 1);
+
+namespace Pyz\Zed\SymfonyMailer\Business;
+
+use Pyz\Zed\SymfonyMailer\Dependency\External\SymfonyMailerToSymfonyMailerAdapter;
+use Spryker\Zed\SymfonyMailer\Business\SymfonyMailerBusinessFactory as SprykerSymfonyMailerBusinessFactory;
+use Spryker\Zed\SymfonyMailer\Dependency\External\SymfonyMailerToMailerInterface;
+
+class SymfonyMailerBusinessFactory extends SprykerSymfonyMailerBusinessFactory
+{
+    /**
+     * @return \Spryker\Zed\SymfonyMailer\Dependency\External\SymfonyMailerToMailerInterface
+     */
+    public function createSymfonyMailerAdapter(): SymfonyMailerToMailerInterface
+    {
+        return new SymfonyMailerToSymfonyMailerAdapter(
+            $this->createRenderer(),
+            $this->createTranslator(),
+            $this->getConfig(),
+        );
+    }
+}

--- a/src/Pyz/Zed/SymfonyMailer/Business/SymfonyMailerBusinessFactory.php
+++ b/src/Pyz/Zed/SymfonyMailer/Business/SymfonyMailerBusinessFactory.php
@@ -13,6 +13,9 @@ use Pyz\Zed\SymfonyMailer\Dependency\External\SymfonyMailerToSymfonyMailerAdapte
 use Spryker\Zed\SymfonyMailer\Business\SymfonyMailerBusinessFactory as SprykerSymfonyMailerBusinessFactory;
 use Spryker\Zed\SymfonyMailer\Dependency\External\SymfonyMailerToMailerInterface;
 
+/**
+ * @method \Spryker\Zed\SymfonyMailer\SymfonyMailerConfig getConfig()
+ */
 class SymfonyMailerBusinessFactory extends SprykerSymfonyMailerBusinessFactory
 {
     /**

--- a/src/Pyz/Zed/SymfonyMailer/Dependency/External/SymfonyMailerToSymfonyMailerAdapter.php
+++ b/src/Pyz/Zed/SymfonyMailer/Dependency/External/SymfonyMailerToSymfonyMailerAdapter.php
@@ -1,0 +1,60 @@
+<?php
+
+/**
+ * This file is part of the Spryker Commerce OS.
+ * For full license information, please view the LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types = 1);
+
+namespace Pyz\Zed\SymfonyMailer\Dependency\External;
+
+use Generated\Shared\Transfer\MailTransfer;
+use Spryker\Zed\SymfonyMailer\Dependency\External\SymfonyMailerToSymfonyMailerAdapter as SprykerSymfonyMailerToSymfonyMailerAdapter;
+
+class SymfonyMailerToSymfonyMailerAdapter extends SprykerSymfonyMailerToSymfonyMailerAdapter
+{
+    /**
+     * @var list<string>
+     */
+    protected const MUTED_EMAIL_PATTERNS = [
+        '@acme.com',
+    ];
+
+    /**
+     * @param \Generated\Shared\Transfer\MailTransfer $mailTransfer
+     *
+     * @return void
+     */
+    public function send(MailTransfer $mailTransfer): void
+    {
+        if ($this->shouldMute($mailTransfer)) {
+            return;
+        }
+
+        parent::send($mailTransfer);
+    }
+
+    /**
+     * @param \Generated\Shared\Transfer\MailTransfer $mailTransfer
+     *
+     * @return bool
+     */
+    protected function shouldMute(MailTransfer $mailTransfer): bool
+    {
+        foreach ($mailTransfer->getRecipients() as $recipientTransfer) {
+            $email = $recipientTransfer->getEmail();
+            if ($email === null) {
+                continue;
+            }
+
+            foreach (static::MUTED_EMAIL_PATTERNS as $pattern) {
+                if (stripos($email, $pattern) !== false) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+}


### PR DESCRIPTION
#### Overview

- Ticket: URL_HERE

###### Change log

{Relevant changes for project level go here.}

###### CI Notice
**Additional tests** can be triggered by adding labels:
- `run-compatibility-ci` runs compatibility tests (PHP 8.3 / PostgreSQL / Debian / Prefer Lowest / Dynamic Store OFF):
    - Codeception / Acceptance & API
    - Codeception / Functional Tests
    - Robot / API
    - Robot / UI
    - Cypress / UI
