### PR TITLE
chore(composer): update spryker/configuration to 1.0.1

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -36529,16 +36529,16 @@
         },
         {
             "name": "spryker/configuration",
-            "version": "1.0.0",
+            "version": "1.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker/configuration.git",
-                "reference": "6d95c3a5bec43c0172d2da498db5f6973e57a675"
+                "reference": "8edda6ffce87ee3e9a5e378a05b87665674b55d7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker/configuration/zipball/6d95c3a5bec43c0172d2da498db5f6973e57a675",
-                "reference": "6d95c3a5bec43c0172d2da498db5f6973e57a675",
+                "url": "https://api.github.com/repos/spryker/configuration/zipball/8edda6ffce87ee3e9a5e378a05b87665674b55d7",
+                "reference": "8edda6ffce87ee3e9a5e378a05b87665674b55d7",
                 "shasum": ""
             },
             "require": {
@@ -36590,9 +36590,9 @@
             ],
             "description": "Configuration module",
             "support": {
-                "source": "https://github.com/spryker/configuration/tree/1.0.0"
+                "source": "https://github.com/spryker/configuration/tree/1.0.1"
             },
-            "time": "2026-04-23T09:50:15+00:00"
+            "time": "2026-05-13T11:56:16+00:00"
         },
         {
             "name": "spryker/configuration-extension",


### PR DESCRIPTION
## Summary
Updates `spryker/configuration` from `1.0.0` to `1.0.1` (latest stable).

## Details
- **Lockfile-only change** — the existing constraint `^1.0.0` in `composer.json` already permits `1.0.1`, so no `composer.json` change was needed.
- Ran `composer update spryker/configuration` (no `--with-dependencies`), so **only this package moved**; transitive dependencies are untouched.
- `plugin-api-version` kept at master's value (`2.9.0`); `content-hash` unchanged (composer.json identical).

Diff scope: a single package block in `composer.lock` — `spryker/configuration 1.0.0 → 1.0.1` (ref `6d95c3a` → `8edda6f`).

## Test plan
- [ ] CI pipeline green