### PR TITLE
CC-39161: update ai-dev to latest (0.6.2)

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -91639,16 +91639,16 @@
         },
         {
             "name": "spryker-sdk/ai-dev",
-            "version": "0.6.0",
+            "version": "0.6.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker-sdk/ai-dev.git",
-                "reference": "6e1e1a86cc358e3d98dcbc0ad500c20378355dbd"
+                "reference": "7d243492d4dd9c0ca054cd0507902abfd50184de"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker-sdk/ai-dev/zipball/6e1e1a86cc358e3d98dcbc0ad500c20378355dbd",
-                "reference": "6e1e1a86cc358e3d98dcbc0ad500c20378355dbd",
+                "url": "https://api.github.com/repos/spryker-sdk/ai-dev/zipball/7d243492d4dd9c0ca054cd0507902abfd50184de",
+                "reference": "7d243492d4dd9c0ca054cd0507902abfd50184de",
                 "shasum": ""
             },
             "require": {
@@ -91690,9 +91690,9 @@
             "description": "AiDev module",
             "support": {
                 "issues": "https://github.com/spryker-sdk/ai-dev/issues",
-                "source": "https://github.com/spryker-sdk/ai-dev/tree/0.6.0"
+                "source": "https://github.com/spryker-sdk/ai-dev/tree/0.6.2"
             },
-            "time": "2026-05-21T09:58:58+00:00"
+            "time": "2026-06-19T06:39:39+00:00"
         },
         {
             "name": "spryker-sdk/benchmark",


### PR DESCRIPTION
#### Overview

- Ticket: https://spryker.atlassian.net/browse/CC-39161

###### Change log

- Updated `spryker-sdk/ai-dev`: `0.6.0` → `0.6.2` (constraint `^0.6.0` unchanged). New commit ref `7d243492…` matches the dev-master commit bumped in suite PR #772.
- Packages added directly: none
- Project changes applied from suite PR 772: 0 files (the suite PR contained only a `composer.lock` change; no source/config/data/frontend changes)
- Conflicts requiring manual review: 0 files
- `plugin-api-version` in `composer.lock` was preserved at `2.9.0` (local composer downgrade reverted)

Note: suite tracks ai-dev as `dev-master`; this demoshop uses tagged releases, so the equivalent integration moves to the latest `0.6.x` tag (`0.6.2`), which resolves to the same commit as the suite PR.

###### CI Notice
**Additional tests** can be triggered by adding labels:
- `run-compatibility-ci` runs compatibility tests (PHP 8.3 / PostgreSQL / Debian / Prefer Lowest / Dynamic Store OFF):
    - Codeception / Acceptance & API
    - Codeception / Functional Tests
    - Robot / API
    - Robot / UI
    - Cypress / UI