### PR TITLE
CC-37851 Updated Cypress version.

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -92086,7 +92086,7 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker/cypress-tests.git",
-                "reference": "09e6cbcfaa2c01c9986d839ed4b9e3e4ff3ec3e1"
+                "reference": "3400c16bffa98b7851b196b5a5e27c781de7e065"
             },
             "default-branch": true,
             "type": "spryker-test",
@@ -92094,7 +92094,7 @@
                 "MIT"
             ],
             "description": "This repository is dedicated to housing an extensive collection of UI end-to-end tests, meticulously crafted using Cypress for Spryker applications. These tests are designed to thoroughly evaluate the user interface, ensuring that all interactions and visual elements function as intended in real-world scenarios. By leveraging Cypress's advanced browser automation capabilities, this suite provides an efficient and effective means of validating the user experience, confirming the seamless operation and aesthetic integrity of Spryker's front-end components. Our commitment to rigorous UI testing helps maintain the high standard of quality and reliability that Spryker users expect.",
-            "time": "2026-06-15T18:10:16+00:00"
+            "time": "2026-06-22T11:20:04+00:00"
         },
         {
             "name": "spryker/development",


### PR DESCRIPTION
#### Overview

- Ticket: https://spryker.atlassian.net/browse/CC-37851

###### Change log

{Relevant changes for project level go here.}

###### CI Notice
**Additional tests** can be triggered by adding labels:
- `run-compatibility-ci` runs compatibility tests (PHP 8.3 / PostgreSQL / Debian / Prefer Lowest / Dynamic Store OFF):
    - Codeception / Acceptance & API
    - Codeception / Functional Tests
    - Robot / API
    - Robot / UI
    - Cypress / UI
