### PR TITLE
Feature/cc 39362/add basic auth to post hook executor fix order add all apps

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -92144,7 +92144,7 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker/cypress-tests.git",
-                "reference": "3083b304748d7c371d0e707fbc4a95c0aa35a56e"
+                "reference": "faf4721558688ebfb650aea971f08901492c2e6a"
             },
             "default-branch": true,
             "type": "spryker-test",
@@ -92152,7 +92152,7 @@
                 "MIT"
             ],
             "description": "This repository is dedicated to housing an extensive collection of UI end-to-end tests, meticulously crafted using Cypress for Spryker applications. These tests are designed to thoroughly evaluate the user interface, ensuring that all interactions and visual elements function as intended in real-world scenarios. By leveraging Cypress's advanced browser automation capabilities, this suite provides an efficient and effective means of validating the user experience, confirming the seamless operation and aesthetic integrity of Spryker's front-end components. Our commitment to rigorous UI testing helps maintain the high standard of quality and reliability that Spryker users expect.",
-            "time": "2026-06-23T11:12:51+00:00"
+            "time": "2026-06-23T13:11:48+00:00"
         },
         {
             "name": "spryker/development",


### PR DESCRIPTION
#### Overview

- Ticket: URL_HERE

###### Change log

{Relevant changes for project level go here.}

###### CI Notice
**Additional tests** can be triggered by adding labels:
- `run-compatibility-ci` runs compatibility tests (PHP 8.3 / PostgreSQL / Debian / Prefer Lowest / Dynamic Store OFF):
    - Codeception / Acceptance & API
    - Codeception / Functional Tests
    - Robot / API
    - Robot / UI
    - Cypress / UI
