### PR TITLE
CC-39427: DemoTest harness + P1/P2 functional coverage (CC-39427)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -78,6 +78,8 @@ npm-debug.log
 /tests/cypress-tests
 /tests/PyzTest/*/*/_output/*
 /tests/PyzTest/*/*/_support/_generated/*
+/tests/DemoTest/*/*/_output/*
+/tests/DemoTest/*/*/_support/_generated/*
 
 /.robot
 /.cypress

--- a/codeception.yml
+++ b/codeception.yml
@@ -3,6 +3,7 @@ actor: Tester
 
 include:
     - tests/PyzTest/*/*
+    - tests/DemoTest/*/*
 
 paths:
     tests: tests
@@ -20,7 +21,7 @@ coverage:
     enabled: true
     remote: true
     c3_url: 'http://backoffice.de.suite.local'
-    whitelist: { include: ['src/Pyz/*.php'] }
+    whitelist: { include: ['src/Pyz/*.php', 'src/Demo/*.php'] }
 
 extensions:
     commands:

--- a/composer.json
+++ b/composer.json
@@ -420,7 +420,8 @@
     },
     "autoload-dev": {
         "psr-4": {
-            "PyzTest\\": "tests/PyzTest/"
+            "PyzTest\\": "tests/PyzTest/",
+            "DemoTest\\": "tests/DemoTest/"
         },
         "files": [
             "test-autoload.php"

--- a/src/Demo/Zed/CmsBlockCustomerGroup/Business/CmsBlockCustomerGroupBusinessFactory.php
+++ b/src/Demo/Zed/CmsBlockCustomerGroup/Business/CmsBlockCustomerGroupBusinessFactory.php
@@ -20,6 +20,7 @@ use Spryker\Zed\Kernel\Business\AbstractBusinessFactory;
 /**
  * @method \Demo\Zed\CmsBlockCustomerGroup\Persistence\CmsBlockCustomerGroupRepositoryInterface getRepository()
  * @method \Demo\Zed\CmsBlockCustomerGroup\Persistence\CmsBlockCustomerGroupEntityManagerInterface getEntityManager()
+ * @method \Demo\Zed\CmsBlockCustomerGroup\CmsBlockCustomerGroupConfig getConfig()
  */
 class CmsBlockCustomerGroupBusinessFactory extends AbstractBusinessFactory
 {

--- a/src/Demo/Zed/CmsBlockCustomerGroup/CmsBlockCustomerGroupConfig.php
+++ b/src/Demo/Zed/CmsBlockCustomerGroup/CmsBlockCustomerGroupConfig.php
@@ -1,0 +1,16 @@
+<?php
+
+/**
+ * This file is part of the Spryker Commerce OS.
+ * For full license information, please view the LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types = 1);
+
+namespace Demo\Zed\CmsBlockCustomerGroup;
+
+use Spryker\Zed\Kernel\AbstractBundleConfig;
+
+class CmsBlockCustomerGroupConfig extends AbstractBundleConfig
+{
+}

--- a/src/Demo/Zed/CmsBlockCustomerGroup/CmsBlockCustomerGroupDependencyProvider.php
+++ b/src/Demo/Zed/CmsBlockCustomerGroup/CmsBlockCustomerGroupDependencyProvider.php
@@ -1,0 +1,16 @@
+<?php
+
+/**
+ * This file is part of the Spryker Commerce OS.
+ * For full license information, please view the LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types = 1);
+
+namespace Demo\Zed\CmsBlockCustomerGroup;
+
+use Spryker\Zed\Kernel\AbstractBundleDependencyProvider;
+
+class CmsBlockCustomerGroupDependencyProvider extends AbstractBundleDependencyProvider
+{
+}

--- a/src/Demo/Zed/CmsBlockCustomerGroup/Persistence/CmsBlockCustomerGroupPersistenceFactory.php
+++ b/src/Demo/Zed/CmsBlockCustomerGroup/Persistence/CmsBlockCustomerGroupPersistenceFactory.php
@@ -17,6 +17,7 @@ use Spryker\Zed\Kernel\Persistence\AbstractPersistenceFactory;
 /**
  * @method \Demo\Zed\CmsBlockCustomerGroup\Persistence\CmsBlockCustomerGroupRepositoryInterface getRepository()
  * @method \Demo\Zed\CmsBlockCustomerGroup\Persistence\CmsBlockCustomerGroupEntityManagerInterface getEntityManager()
+ * @method \Demo\Zed\CmsBlockCustomerGroup\CmsBlockCustomerGroupConfig getConfig()
  */
 class CmsBlockCustomerGroupPersistenceFactory extends AbstractPersistenceFactory
 {

--- a/test-autoload.php
+++ b/test-autoload.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 $autoloader = function ($className) {
     $className = ltrim($className, '\\');
     $classNameParts = explode('\\', $className);
@@ -14,6 +16,22 @@ $autoloader = function ($className) {
             __DIR__,
             'tests',
             'PyzTest',
+            $application,
+            $bundle,
+            '_support',
+            $className . '.php',
+        ];
+    }
+
+    if ($classNameParts[0] === 'DemoTest') {
+        array_shift($classNameParts);
+        $application = array_shift($classNameParts);
+        $bundle = array_shift($classNameParts);
+        $className = implode(DIRECTORY_SEPARATOR, $classNameParts);
+        $filePathPartsSupport = [
+            __DIR__,
+            'tests',
+            'DemoTest',
             $application,
             $bundle,
             '_support',

--- a/tests/DemoTest/Client/PriceProduct/ProductPriceResolverTest.php
+++ b/tests/DemoTest/Client/PriceProduct/ProductPriceResolverTest.php
@@ -1,0 +1,95 @@
+<?php
+
+/**
+ * This file is part of the Spryker Commerce OS.
+ * For full license information, please view the LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types = 1);
+
+namespace DemoTest\Client\PriceProduct;
+
+use Codeception\Test\Unit;
+use Demo\Shared\Price\PriceConfig;
+use Spryker\Client\Session\SessionClient;
+use Spryker\Shared\Price\PriceConfig as SprykerPriceConfig;
+use Symfony\Component\HttpFoundation\Session\Session;
+use Symfony\Component\HttpFoundation\Session\Storage\MockArraySessionStorage;
+
+/**
+ * @group DemoTest
+ * @group Client
+ * @group PriceProduct
+ * @group ProductPriceResolverTest
+ */
+class ProductPriceResolverTest extends Unit
+{
+    protected const int GROSS_AMOUNT = 12000;
+
+    protected const int NET_AMOUNT = 10000;
+
+    protected const int COST_AMOUNT = 6000;
+
+    protected const int EXPECTED_GROSS_MARGIN = 40;
+
+    protected PriceProductClientTester $tester;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->bootstrapQuoteSession();
+    }
+
+    public function testResolveProductPriceTransferComputesGrossMarginFromNetAndCost(): void
+    {
+        // Arrange
+        $priceProductTransfer = $this->tester->createPriceProductTransfer(static::GROSS_AMOUNT, static::NET_AMOUNT, static::COST_AMOUNT);
+        $priceProductFilterTransfer = $this->tester->createFilter(SprykerPriceConfig::PRICE_MODE_NET);
+
+        // Act
+        $currentProductPriceTransfer = $this->tester->getClient()
+            ->resolveProductPriceTransferByPriceProductFilter([$priceProductTransfer], $priceProductFilterTransfer);
+
+        // Assert
+        $this->assertSame(static::EXPECTED_GROSS_MARGIN, $currentProductPriceTransfer->getGrossMargin());
+    }
+
+    public function testResolveProductPriceTransferReturnsZeroGrossMarginWhenCostMissing(): void
+    {
+        // Arrange
+        $priceProductTransfer = $this->tester->createPriceProductTransfer(static::GROSS_AMOUNT, static::NET_AMOUNT, null);
+        $priceProductFilterTransfer = $this->tester->createFilter(SprykerPriceConfig::PRICE_MODE_NET);
+
+        // Act
+        $currentProductPriceTransfer = $this->tester->getClient()
+            ->resolveProductPriceTransferByPriceProductFilter([$priceProductTransfer], $priceProductFilterTransfer);
+
+        // Assert
+        $this->assertSame(0, $currentProductPriceTransfer->getGrossMargin());
+    }
+
+    public function testResolveProductPriceTransferReturnsCostAmountForCostMode(): void
+    {
+        // Arrange
+        $priceProductTransfer = $this->tester->createPriceProductTransfer(static::GROSS_AMOUNT, static::NET_AMOUNT, static::COST_AMOUNT);
+        $priceProductFilterTransfer = $this->tester->createFilter(PriceConfig::PRICE_MODE_COST);
+
+        // Act
+        $currentProductPriceTransfer = $this->tester->getClient()
+            ->resolveProductPriceTransferByPriceProductFilter([$priceProductTransfer], $priceProductFilterTransfer);
+
+        // Assert
+        $this->assertSame(static::COST_AMOUNT, $currentProductPriceTransfer->getPrice());
+    }
+
+    /**
+     * The resolver eagerly reads the current price mode and currency from the quote session
+     * before the filter fallbacks apply, so the session container must be initialized.
+     */
+    protected function bootstrapQuoteSession(): void
+    {
+        $sessionClient = new SessionClient();
+        $sessionClient->setContainer(new Session(new MockArraySessionStorage()));
+    }
+}

--- a/tests/DemoTest/Client/PriceProduct/_support/PriceProductClientTester.php
+++ b/tests/DemoTest/Client/PriceProduct/_support/PriceProductClientTester.php
@@ -1,0 +1,72 @@
+<?php
+
+/**
+ * This file is part of the Spryker Commerce OS.
+ * For full license information, please view the LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types = 1);
+
+namespace DemoTest\Client\PriceProduct;
+
+use Codeception\Actor;
+use Generated\Shared\Transfer\CurrencyTransfer;
+use Generated\Shared\Transfer\MoneyValueTransfer;
+use Generated\Shared\Transfer\PriceProductDimensionTransfer;
+use Generated\Shared\Transfer\PriceProductFilterTransfer;
+use Generated\Shared\Transfer\PriceProductTransfer;
+use Spryker\Client\PriceProduct\PriceProductClientInterface;
+use Spryker\Shared\PriceProduct\PriceProductConfig;
+
+/**
+ * Inherited Methods
+ *
+ * @method void wantToTest($text)
+ * @method void wantTo($text)
+ * @method void execute($callable)
+ * @method void expectTo($prediction)
+ * @method void expect($prediction)
+ * @method void amGoingTo($argumentation)
+ * @method void am($role)
+ * @method void lookForwardTo($achieveValue)
+ * @method void comment($description)
+ * @method \Codeception\Lib\Friend haveFriend($name, $actorClass = NULL)
+ *
+ * @SuppressWarnings(\DemoTest\Client\PriceProduct\PHPMD)
+ */
+class PriceProductClientTester extends Actor
+{
+    use _generated\PriceProductClientTesterActions;
+
+    public const string CURRENCY_ISO_CODE = 'EUR';
+
+    public const string PRICE_TYPE_NAME = 'DEFAULT';
+
+    public function createPriceProductTransfer(int $grossAmount, int $netAmount, ?int $costAmount): PriceProductTransfer
+    {
+        $moneyValueTransfer = (new MoneyValueTransfer())
+            ->setGrossAmount($grossAmount)
+            ->setNetAmount($netAmount)
+            ->setCostAmount($costAmount)
+            ->setCurrency((new CurrencyTransfer())->setCode(static::CURRENCY_ISO_CODE));
+
+        return (new PriceProductTransfer())
+            ->setPriceTypeName(static::PRICE_TYPE_NAME)
+            ->setPriceDimension((new PriceProductDimensionTransfer())->setType(PriceProductConfig::PRICE_DIMENSION_DEFAULT))
+            ->setMoneyValue($moneyValueTransfer);
+    }
+
+    public function createFilter(string $priceMode): PriceProductFilterTransfer
+    {
+        return (new PriceProductFilterTransfer())
+            ->setPriceMode($priceMode)
+            ->setPriceTypeName(static::PRICE_TYPE_NAME)
+            ->setCurrencyIsoCode(static::CURRENCY_ISO_CODE)
+            ->setQuantity(1);
+    }
+
+    public function getClient(): PriceProductClientInterface
+    {
+        return $this->getLocator()->priceProduct()->client();
+    }
+}

--- a/tests/DemoTest/Client/PriceProduct/codeception.yml
+++ b/tests/DemoTest/Client/PriceProduct/codeception.yml
@@ -1,0 +1,27 @@
+namespace: DemoTest\Client\PriceProduct
+
+paths:
+    tests: .
+    data: _data
+    support: _support
+    output: _output
+
+coverage:
+    enabled: true
+    remote: false
+    whitelist: { include: ['../../../../src/*'] }
+
+suites:
+    Client:
+        path: .
+        actor: PriceProductClientTester
+        modules:
+            enabled:
+                - Asserts
+                - \PyzTest\Shared\Testify\Helper\Environment
+                - \SprykerTest\Shared\Testify\Helper\ConfigHelper
+                - \SprykerTest\Shared\Testify\Helper\LocatorHelper:
+                    projectNamespaces: ['Demo', 'Pyz']
+                - \SprykerTest\Shared\Testify\Helper\DependencyHelper
+                - \SprykerTest\Service\Container\Helper\ContainerHelper
+                - \SprykerTest\Shared\Store\Helper\StoreDependencyHelper

--- a/tests/DemoTest/Client/ProductGrossMargin/ProductViewGrossMarginExpanderPluginTest.php
+++ b/tests/DemoTest/Client/ProductGrossMargin/ProductViewGrossMarginExpanderPluginTest.php
@@ -1,0 +1,58 @@
+<?php
+
+/**
+ * This file is part of the Spryker Commerce OS.
+ * For full license information, please view the LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types = 1);
+
+namespace DemoTest\Client\ProductGrossMargin;
+
+use Codeception\Test\Unit;
+use Demo\Client\ProductGrossMargin\Plugin\ProductStorage\ProductViewGrossMarginExpanderPlugin;
+use Generated\Shared\Transfer\CurrentProductPriceTransfer;
+use Generated\Shared\Transfer\ProductViewTransfer;
+
+/**
+ * @group DemoTest
+ * @group Client
+ * @group ProductGrossMargin
+ * @group ProductViewGrossMarginExpanderPluginTest
+ */
+class ProductViewGrossMarginExpanderPluginTest extends Unit
+{
+    protected const string LOCALE_NAME = 'de_DE';
+
+    protected const int GROSS_MARGIN = 42;
+
+    protected ProductGrossMarginClientTester $tester;
+
+    public function testExpandProductViewTransferCopiesGrossMarginFromCurrentProductPrice(): void
+    {
+        // Arrange
+        $productViewTransfer = (new ProductViewTransfer())->setCurrentProductPrice(
+            (new CurrentProductPriceTransfer())->setGrossMargin(static::GROSS_MARGIN),
+        );
+
+        // Act
+        $resultProductViewTransfer = (new ProductViewGrossMarginExpanderPlugin())
+            ->expandProductViewTransfer($productViewTransfer, [], static::LOCALE_NAME);
+
+        // Assert
+        $this->assertSame(static::GROSS_MARGIN, $resultProductViewTransfer->getGrossMargin());
+    }
+
+    public function testExpandProductViewTransferDefaultsToZeroWhenCurrentProductPriceMissing(): void
+    {
+        // Arrange
+        $productViewTransfer = new ProductViewTransfer();
+
+        // Act
+        $resultProductViewTransfer = (new ProductViewGrossMarginExpanderPlugin())
+            ->expandProductViewTransfer($productViewTransfer, [], static::LOCALE_NAME);
+
+        // Assert
+        $this->assertSame(0, $resultProductViewTransfer->getGrossMargin());
+    }
+}

--- a/tests/DemoTest/Client/ProductGrossMargin/_support/ProductGrossMarginClientTester.php
+++ b/tests/DemoTest/Client/ProductGrossMargin/_support/ProductGrossMarginClientTester.php
@@ -1,0 +1,33 @@
+<?php
+
+/**
+ * This file is part of the Spryker Commerce OS.
+ * For full license information, please view the LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types = 1);
+
+namespace DemoTest\Client\ProductGrossMargin;
+
+use Codeception\Actor;
+
+/**
+ * Inherited Methods
+ *
+ * @method void wantToTest($text)
+ * @method void wantTo($text)
+ * @method void execute($callable)
+ * @method void expectTo($prediction)
+ * @method void expect($prediction)
+ * @method void amGoingTo($argumentation)
+ * @method void am($role)
+ * @method void lookForwardTo($achieveValue)
+ * @method void comment($description)
+ * @method \Codeception\Lib\Friend haveFriend($name, $actorClass = NULL)
+ *
+ * @SuppressWarnings(\DemoTest\Client\ProductGrossMargin\PHPMD)
+ */
+class ProductGrossMarginClientTester extends Actor
+{
+    use _generated\ProductGrossMarginClientTesterActions;
+}

--- a/tests/DemoTest/Client/ProductGrossMargin/codeception.yml
+++ b/tests/DemoTest/Client/ProductGrossMargin/codeception.yml
@@ -1,0 +1,23 @@
+namespace: DemoTest\Client\ProductGrossMargin
+
+paths:
+    tests: .
+    data: _data
+    support: _support
+    output: _output
+
+coverage:
+    enabled: true
+    remote: false
+    whitelist: { include: ['../../../../src/*'] }
+
+suites:
+    Client:
+        path: .
+        actor: ProductGrossMarginClientTester
+        modules:
+            enabled:
+                - Asserts
+                - \PyzTest\Shared\Testify\Helper\Environment
+                - \SprykerTest\Shared\Testify\Helper\LocatorHelper:
+                    projectNamespaces: ['Demo', 'Pyz']

--- a/tests/DemoTest/Zed/CmsBlockCustomerGroup/Business/CmsBlockCustomerGroupFacadeTest.php
+++ b/tests/DemoTest/Zed/CmsBlockCustomerGroup/Business/CmsBlockCustomerGroupFacadeTest.php
@@ -1,0 +1,199 @@
+<?php
+
+/**
+ * This file is part of the Spryker Commerce OS.
+ * For full license information, please view the LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types = 1);
+
+namespace DemoTest\Zed\CmsBlockCustomerGroup\Business;
+
+use Codeception\Test\Unit;
+use Demo\Zed\CmsBlockCustomerGroup\Business\CmsBlockCustomerGroupFacadeInterface;
+use DemoTest\Zed\CmsBlockCustomerGroup\CmsBlockCustomerGroupBusinessTester;
+use Generated\Shared\Transfer\CmsBlockTransfer;
+use Generated\Shared\Transfer\CmsBlockValidationRequestTransfer;
+use Generated\Shared\Transfer\CustomerGroupCollectionTransfer;
+use Generated\Shared\Transfer\CustomerGroupTransfer;
+use Generated\Shared\Transfer\CustomerTransfer;
+use Orm\Zed\CmsBlockCustomerGroup\Persistence\PyzCmsBlockCustomerGroupQuery;
+
+/**
+ * @group DemoTest
+ * @group Zed
+ * @group CmsBlockCustomerGroup
+ * @group Business
+ * @group CmsBlockCustomerGroupFacadeTest
+ */
+class CmsBlockCustomerGroupFacadeTest extends Unit
+{
+    protected CmsBlockCustomerGroupBusinessTester $tester;
+
+    public function testValidateAccessGivenBlockWithoutAssignedGroupsWhenAnyCustomerThenAccessGranted(): void
+    {
+        // Arrange
+        $cmsBlockTransfer = $this->tester->haveCmsBlock();
+        $customerTransfer = $this->tester->haveCustomer();
+        $requestTransfer = $this->createValidationRequest($cmsBlockTransfer, $customerTransfer);
+
+        // Act
+        $responseTransfer = $this->getFacade()->validateAccessToCmsBlock($requestTransfer);
+
+        // Assert
+        $this->assertTrue($responseTransfer->getIsValid());
+    }
+
+    public function testValidateAccessGivenCustomerInAssignedGroupThenAccessGranted(): void
+    {
+        // Arrange
+        $cmsBlockTransfer = $this->tester->haveCmsBlock();
+        $customerTransfer = $this->tester->haveCustomer();
+        $customerGroupTransfer = $this->tester->haveCustomerGroup();
+        $this->tester->assignCustomerToGroup($customerTransfer->getIdCustomer(), $customerGroupTransfer->getIdCustomerGroup());
+        $this->assignGroupsToCmsBlock($cmsBlockTransfer, [$customerGroupTransfer->getIdCustomerGroup()]);
+
+        // Act
+        $responseTransfer = $this->getFacade()->validateAccessToCmsBlock(
+            $this->createValidationRequest($cmsBlockTransfer, $customerTransfer),
+        );
+
+        // Assert
+        $this->assertTrue($responseTransfer->getIsValid());
+    }
+
+    public function testValidateAccessGivenCustomerNotInAssignedGroupThenAccessDenied(): void
+    {
+        // Arrange
+        $cmsBlockTransfer = $this->tester->haveCmsBlock();
+        $customerTransfer = $this->tester->haveCustomer();
+        $customerGroupTransfer = $this->tester->haveCustomerGroup();
+        $this->assignGroupsToCmsBlock($cmsBlockTransfer, [$customerGroupTransfer->getIdCustomerGroup()]);
+
+        // Act
+        $responseTransfer = $this->getFacade()->validateAccessToCmsBlock(
+            $this->createValidationRequest($cmsBlockTransfer, $customerTransfer),
+        );
+
+        // Assert
+        $this->assertFalse($responseTransfer->getIsValid());
+    }
+
+    public function testValidateAccessGivenNoCustomerThenAccessDenied(): void
+    {
+        // Arrange
+        $cmsBlockTransfer = $this->tester->haveCmsBlock();
+        $requestTransfer = (new CmsBlockValidationRequestTransfer())
+            ->setCmsBlock($cmsBlockTransfer)
+            ->setCustomer(null);
+
+        // Act
+        $responseTransfer = $this->getFacade()->validateAccessToCmsBlock($requestTransfer);
+
+        // Assert
+        $this->assertFalse($responseTransfer->getIsValid());
+    }
+
+    public function testSaveCmsBlockCustomerGroupsDiffsAddsAndRemoves(): void
+    {
+        // Arrange
+        $cmsBlockTransfer = $this->tester->haveCmsBlock();
+        $idCustomerGroupA = $this->tester->haveCustomerGroup()->getIdCustomerGroup();
+        $idCustomerGroupB = $this->tester->haveCustomerGroup()->getIdCustomerGroup();
+        $idCustomerGroupC = $this->tester->haveCustomerGroup()->getIdCustomerGroup();
+        $this->assignGroupsToCmsBlock($cmsBlockTransfer, [$idCustomerGroupA, $idCustomerGroupB]);
+
+        // Act
+        $this->assignGroupsToCmsBlock($cmsBlockTransfer, [$idCustomerGroupB, $idCustomerGroupC]);
+
+        // Assert
+        $this->assertSame(
+            $this->sortedUnique([$idCustomerGroupB, $idCustomerGroupC]),
+            $this->getAssignedCustomerGroupIds($cmsBlockTransfer),
+        );
+        $this->assertSame(2, $this->countCmsBlockCustomerGroupRows($cmsBlockTransfer->getIdCmsBlock()));
+    }
+
+    public function testGetCmsBlockCustomerGroupsReturnsAssignedCollection(): void
+    {
+        // Arrange
+        $cmsBlockTransfer = $this->tester->haveCmsBlock();
+        $idCustomerGroupA = $this->tester->haveCustomerGroup()->getIdCustomerGroup();
+        $this->assignGroupsToCmsBlock($cmsBlockTransfer, [$idCustomerGroupA]);
+
+        // Act
+        $customerGroupCollectionTransfer = $this->getFacade()->getCmsBlockCustomerGroups($cmsBlockTransfer);
+
+        // Assert
+        $this->assertCount(1, $customerGroupCollectionTransfer->getGroups());
+        $this->assertSame($idCustomerGroupA, $customerGroupCollectionTransfer->getGroups()[0]->getIdCustomerGroup());
+    }
+
+    /**
+     * @param \Generated\Shared\Transfer\CmsBlockTransfer $cmsBlockTransfer
+     * @param array<int> $customerGroupIds
+     *
+     * @return void
+     */
+    protected function assignGroupsToCmsBlock(CmsBlockTransfer $cmsBlockTransfer, array $customerGroupIds): void
+    {
+        $customerGroupCollectionTransfer = new CustomerGroupCollectionTransfer();
+        foreach ($customerGroupIds as $idCustomerGroup) {
+            $customerGroupCollectionTransfer->addGroup(
+                (new CustomerGroupTransfer())->setIdCustomerGroup($idCustomerGroup),
+            );
+        }
+
+        $cmsBlockTransfer->setCustomerGroups($customerGroupCollectionTransfer);
+        $this->getFacade()->saveCmsBlockCustomerGroups($cmsBlockTransfer);
+    }
+
+    /**
+     * @param \Generated\Shared\Transfer\CmsBlockTransfer $cmsBlockTransfer
+     *
+     * @return array<int>
+     */
+    protected function getAssignedCustomerGroupIds(CmsBlockTransfer $cmsBlockTransfer): array
+    {
+        $customerGroupIds = [];
+        foreach ($this->getFacade()->getCmsBlockCustomerGroups($cmsBlockTransfer)->getGroups() as $customerGroupTransfer) {
+            $customerGroupIds[] = $customerGroupTransfer->getIdCustomerGroup();
+        }
+
+        return $this->sortedUnique($customerGroupIds);
+    }
+
+    protected function countCmsBlockCustomerGroupRows(int $idCmsBlock): int
+    {
+        return PyzCmsBlockCustomerGroupQuery::create()
+            ->filterByFkCmsBlock($idCmsBlock)
+            ->count();
+    }
+
+    protected function createValidationRequest(
+        CmsBlockTransfer $cmsBlockTransfer,
+        CustomerTransfer $customerTransfer,
+    ): CmsBlockValidationRequestTransfer {
+        return (new CmsBlockValidationRequestTransfer())
+            ->setCmsBlock($cmsBlockTransfer)
+            ->setCustomer($customerTransfer);
+    }
+
+    /**
+     * @param array<int> $values
+     *
+     * @return array<int>
+     */
+    protected function sortedUnique(array $values): array
+    {
+        $values = array_values(array_unique($values));
+        sort($values);
+
+        return $values;
+    }
+
+    protected function getFacade(): CmsBlockCustomerGroupFacadeInterface
+    {
+        return $this->tester->getLocator()->cmsBlockCustomerGroup()->facade();
+    }
+}

--- a/tests/DemoTest/Zed/CmsBlockCustomerGroup/_support/CmsBlockCustomerGroupBusinessTester.php
+++ b/tests/DemoTest/Zed/CmsBlockCustomerGroup/_support/CmsBlockCustomerGroupBusinessTester.php
@@ -1,0 +1,45 @@
+<?php
+
+/**
+ * This file is part of the Spryker Commerce OS.
+ * For full license information, please view the LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types = 1);
+
+namespace DemoTest\Zed\CmsBlockCustomerGroup;
+
+use Codeception\Actor;
+use Orm\Zed\CustomerGroup\Persistence\SpyCustomerGroupToCustomer;
+
+/**
+ * Inherited Methods
+ *
+ * @method void wantToTest($text)
+ * @method void wantTo($text)
+ * @method void execute($callable)
+ * @method void expectTo($prediction)
+ * @method void expect($prediction)
+ * @method void amGoingTo($argumentation)
+ * @method void am($role)
+ * @method void lookForwardTo($achieveValue)
+ * @method void comment($description)
+ * @method \Codeception\Lib\Friend haveFriend($name, $actorClass = NULL)
+ * @method \Generated\Shared\Transfer\CmsBlockTransfer haveCmsBlock(array $seedData = [])
+ * @method \Generated\Shared\Transfer\CustomerTransfer haveCustomer(array $override = [])
+ * @method \Generated\Shared\Transfer\CustomerGroupTransfer haveCustomerGroup(array $seed = [])
+ *
+ * @SuppressWarnings(\DemoTest\Zed\CmsBlockCustomerGroup\PHPMD)
+ */
+class CmsBlockCustomerGroupBusinessTester extends Actor
+{
+    use _generated\CmsBlockCustomerGroupBusinessTesterActions;
+
+    public function assignCustomerToGroup(int $idCustomer, int $idCustomerGroup): void
+    {
+        $customerGroupToCustomerEntity = new SpyCustomerGroupToCustomer();
+        $customerGroupToCustomerEntity->setFkCustomer($idCustomer);
+        $customerGroupToCustomerEntity->setFkCustomerGroup($idCustomerGroup);
+        $customerGroupToCustomerEntity->save();
+    }
+}

--- a/tests/DemoTest/Zed/CmsBlockCustomerGroup/codeception.yml
+++ b/tests/DemoTest/Zed/CmsBlockCustomerGroup/codeception.yml
@@ -1,0 +1,31 @@
+namespace: DemoTest\Zed\CmsBlockCustomerGroup
+
+paths:
+    tests: .
+    data: _data
+    support: _support
+    output: _output
+
+coverage:
+    enabled: true
+    remote: false
+    whitelist: { include: ['../../../../src/*'] }
+
+suites:
+    Business:
+        path: Business
+        actor: CmsBlockCustomerGroupBusinessTester
+        modules:
+            enabled:
+                - Asserts
+                - \PyzTest\Shared\Testify\Helper\Environment
+                - \SprykerTest\Shared\Testify\Helper\LocatorHelper:
+                    projectNamespaces: ['Demo', 'Pyz']
+                - \SprykerTest\Shared\Testify\Helper\DataCleanupHelper
+                - \SprykerTest\Shared\Propel\Helper\TransactionHelper
+                - \SprykerTest\Shared\Testify\Helper\DependencyHelper
+                - \SprykerTest\Service\Container\Helper\ContainerHelper
+                - \SprykerTest\Shared\Store\Helper\StoreDependencyHelper
+                - \SprykerTest\Zed\CmsBlock\Helper\CmsBlockDataHelper
+                - \SprykerTest\Shared\Customer\Helper\CustomerDataHelper
+                - \SprykerTest\Zed\CustomerGroup\Helper\CustomerGroupHelper

--- a/tests/DemoTest/Zed/CustomerGroup/Business/CustomerGroupFacadeTest.php
+++ b/tests/DemoTest/Zed/CustomerGroup/Business/CustomerGroupFacadeTest.php
@@ -1,0 +1,66 @@
+<?php
+
+/**
+ * This file is part of the Spryker Commerce OS.
+ * For full license information, please view the LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types = 1);
+
+namespace DemoTest\Zed\CustomerGroup\Business;
+
+use Codeception\Test\Unit;
+use Demo\Zed\CustomerGroup\Business\CustomerGroupFacadeInterface;
+use DemoTest\Zed\CustomerGroup\CustomerGroupBusinessTester;
+use Generated\Shared\Transfer\CustomerGroupTransfer;
+
+/**
+ * @group DemoTest
+ * @group Zed
+ * @group CustomerGroup
+ * @group Business
+ * @group CustomerGroupFacadeTest
+ */
+class CustomerGroupFacadeTest extends Unit
+{
+    protected CustomerGroupBusinessTester $tester;
+
+    public function testGetCustomerGroupCollectionMapsIdAndNameFromDatabase(): void
+    {
+        // Arrange
+        $customerGroupTransfer = $this->tester->haveCustomerGroup();
+
+        // Act
+        $customerGroupCollectionTransfer = $this->getFacade()->getCustomerGroupCollection();
+
+        // Assert
+        $matchingGroupTransfer = $this->findGroupById(
+            $customerGroupCollectionTransfer->getGroups()->getArrayCopy(),
+            $customerGroupTransfer->getIdCustomerGroup(),
+        );
+        $this->assertNotNull($matchingGroupTransfer);
+        $this->assertSame($customerGroupTransfer->getName(), $matchingGroupTransfer->getName());
+    }
+
+    /**
+     * @param array<\Generated\Shared\Transfer\CustomerGroupTransfer> $customerGroupTransfers
+     * @param int $idCustomerGroup
+     *
+     * @return \Generated\Shared\Transfer\CustomerGroupTransfer|null
+     */
+    protected function findGroupById(array $customerGroupTransfers, int $idCustomerGroup): ?CustomerGroupTransfer
+    {
+        foreach ($customerGroupTransfers as $customerGroupTransfer) {
+            if ($customerGroupTransfer->getIdCustomerGroup() === $idCustomerGroup) {
+                return $customerGroupTransfer;
+            }
+        }
+
+        return null;
+    }
+
+    protected function getFacade(): CustomerGroupFacadeInterface
+    {
+        return $this->tester->getLocator()->customerGroup()->facade();
+    }
+}

--- a/tests/DemoTest/Zed/CustomerGroup/_support/CustomerGroupBusinessTester.php
+++ b/tests/DemoTest/Zed/CustomerGroup/_support/CustomerGroupBusinessTester.php
@@ -1,0 +1,34 @@
+<?php
+
+/**
+ * This file is part of the Spryker Commerce OS.
+ * For full license information, please view the LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types = 1);
+
+namespace DemoTest\Zed\CustomerGroup;
+
+use Codeception\Actor;
+
+/**
+ * Inherited Methods
+ *
+ * @method void wantToTest($text)
+ * @method void wantTo($text)
+ * @method void execute($callable)
+ * @method void expectTo($prediction)
+ * @method void expect($prediction)
+ * @method void amGoingTo($argumentation)
+ * @method void am($role)
+ * @method void lookForwardTo($achieveValue)
+ * @method void comment($description)
+ * @method \Codeception\Lib\Friend haveFriend($name, $actorClass = NULL)
+ * @method \Generated\Shared\Transfer\CustomerGroupTransfer haveCustomerGroup(array $seed = [])
+ *
+ * @SuppressWarnings(\DemoTest\Zed\CustomerGroup\PHPMD)
+ */
+class CustomerGroupBusinessTester extends Actor
+{
+    use _generated\CustomerGroupBusinessTesterActions;
+}

--- a/tests/DemoTest/Zed/CustomerGroup/codeception.yml
+++ b/tests/DemoTest/Zed/CustomerGroup/codeception.yml
@@ -1,0 +1,29 @@
+namespace: DemoTest\Zed\CustomerGroup
+
+paths:
+    tests: .
+    data: _data
+    support: _support
+    output: _output
+
+coverage:
+    enabled: true
+    remote: false
+    whitelist: { include: ['../../../../src/*'] }
+
+suites:
+    Business:
+        path: Business
+        actor: CustomerGroupBusinessTester
+        modules:
+            enabled:
+                - Asserts
+                - \PyzTest\Shared\Testify\Helper\Environment
+                - \SprykerTest\Shared\Testify\Helper\LocatorHelper:
+                    projectNamespaces: ['Demo', 'Pyz']
+                - \SprykerTest\Shared\Testify\Helper\DataCleanupHelper
+                - \SprykerTest\Shared\Propel\Helper\TransactionHelper
+                - \SprykerTest\Shared\Testify\Helper\DependencyHelper
+                - \SprykerTest\Service\Container\Helper\ContainerHelper
+                - \SprykerTest\Shared\Store\Helper\StoreDependencyHelper
+                - \SprykerTest\Zed\CustomerGroup\Helper\CustomerGroupHelper

--- a/tests/DemoTest/Zed/PriceCartConnector/Business/PriceManagerTest.php
+++ b/tests/DemoTest/Zed/PriceCartConnector/Business/PriceManagerTest.php
@@ -1,0 +1,62 @@
+<?php
+
+/**
+ * This file is part of the Spryker Commerce OS.
+ * For full license information, please view the LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types = 1);
+
+namespace DemoTest\Zed\PriceCartConnector\Business;
+
+use Codeception\Test\Unit;
+use DemoTest\Zed\PriceCartConnector\PriceCartConnectorBusinessTester;
+
+/**
+ * @group DemoTest
+ * @group Zed
+ * @group PriceCartConnector
+ * @group Business
+ * @group PriceManagerTest
+ */
+class PriceManagerTest extends Unit
+{
+    protected const int GROSS_AMOUNT = 10000;
+
+    protected const int NET_AMOUNT = 8403;
+
+    protected const int COST_AMOUNT = 6000;
+
+    protected const int EXPECTED_GROSS_MARGIN = 40;
+
+    protected PriceCartConnectorBusinessTester $tester;
+
+    public function testAddPriceToItemsSetsGrossMarginFromGrossAndCostPrices(): void
+    {
+        // Arrange
+        $productConcreteTransfer = $this->tester->haveProductWithPrice(static::GROSS_AMOUNT, static::NET_AMOUNT, static::COST_AMOUNT);
+        $cartChangeTransfer = $this->tester->createCartChangeForSku($productConcreteTransfer->getSku());
+
+        // Act
+        $cartChangeTransfer = $this->tester->getFacade()->addPriceToItems($cartChangeTransfer);
+
+        // Assert
+        $itemTransfer = $cartChangeTransfer->getItems()->offsetGet(0);
+        $this->assertSame(static::EXPECTED_GROSS_MARGIN, $itemTransfer->getGrossMargin());
+        $this->assertSame(static::COST_AMOUNT, $itemTransfer->getUnitCostPrice());
+    }
+
+    public function testAddPriceToItemsSetsZeroGrossMarginWhenCostMissing(): void
+    {
+        // Arrange
+        $productConcreteTransfer = $this->tester->haveProductWithPrice(static::GROSS_AMOUNT, static::NET_AMOUNT, null);
+        $cartChangeTransfer = $this->tester->createCartChangeForSku($productConcreteTransfer->getSku());
+
+        // Act
+        $cartChangeTransfer = $this->tester->getFacade()->addPriceToItems($cartChangeTransfer);
+
+        // Assert
+        $itemTransfer = $cartChangeTransfer->getItems()->offsetGet(0);
+        $this->assertSame(0, $itemTransfer->getGrossMargin());
+    }
+}

--- a/tests/DemoTest/Zed/PriceCartConnector/_support/PriceCartConnectorBusinessTester.php
+++ b/tests/DemoTest/Zed/PriceCartConnector/_support/PriceCartConnectorBusinessTester.php
@@ -1,0 +1,90 @@
+<?php
+
+/**
+ * This file is part of the Spryker Commerce OS.
+ * For full license information, please view the LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types = 1);
+
+namespace DemoTest\Zed\PriceCartConnector;
+
+use Codeception\Actor;
+use Generated\Shared\Transfer\CartChangeTransfer;
+use Generated\Shared\Transfer\CurrencyTransfer;
+use Generated\Shared\Transfer\ItemTransfer;
+use Generated\Shared\Transfer\MoneyValueTransfer;
+use Generated\Shared\Transfer\PriceProductTransfer;
+use Generated\Shared\Transfer\ProductConcreteTransfer;
+use Generated\Shared\Transfer\QuoteTransfer;
+use Generated\Shared\Transfer\StoreTransfer;
+use Spryker\Shared\Price\PriceConfig;
+
+/**
+ * Inherited Methods
+ *
+ * @method void wantToTest($text)
+ * @method void wantTo($text)
+ * @method void execute($callable)
+ * @method void expectTo($prediction)
+ * @method void expect($prediction)
+ * @method void amGoingTo($argumentation)
+ * @method void am($role)
+ * @method void lookForwardTo($achieveValue)
+ * @method void comment($description)
+ * @method \Codeception\Lib\Friend haveFriend($name, $actorClass = NULL)
+ * @method \Spryker\Zed\PriceCartConnector\Business\PriceCartConnectorFacadeInterface getFacade()
+ *
+ * @SuppressWarnings(\DemoTest\Zed\PriceCartConnector\PHPMD)
+ */
+class PriceCartConnectorBusinessTester extends Actor
+{
+    use _generated\PriceCartConnectorBusinessTesterActions;
+
+    public const string STORE_NAME = 'DE';
+
+    public const string CURRENCY_ISO_CODE = 'EUR';
+
+    public function haveProductWithPrice(int $grossAmount, int $netAmount, ?int $costAmount): ProductConcreteTransfer
+    {
+        $productConcreteTransfer = $this->haveProduct();
+
+        $this->havePriceProduct([
+            PriceProductTransfer::SKU_PRODUCT_ABSTRACT => $productConcreteTransfer->getAbstractSku(),
+            PriceProductTransfer::SKU_PRODUCT => $productConcreteTransfer->getSku(),
+            PriceProductTransfer::ID_PRODUCT => $productConcreteTransfer->getIdProductConcrete(),
+            PriceProductTransfer::ID_PRODUCT_ABSTRACT => $productConcreteTransfer->getFkProductAbstract(),
+            PriceProductTransfer::MONEY_VALUE => [
+                MoneyValueTransfer::GROSS_AMOUNT => $grossAmount,
+                MoneyValueTransfer::NET_AMOUNT => $netAmount,
+                MoneyValueTransfer::COST_AMOUNT => $costAmount,
+                MoneyValueTransfer::STORE => $this->getStoreTransfer(),
+                MoneyValueTransfer::CURRENCY => $this->getCurrencyTransfer(),
+            ],
+        ]);
+
+        return $productConcreteTransfer;
+    }
+
+    public function createCartChangeForSku(string $sku): CartChangeTransfer
+    {
+        $quoteTransfer = (new QuoteTransfer())
+            ->setStore($this->getStoreTransfer())
+            ->setCurrency($this->getCurrencyTransfer())
+            ->setPriceMode(PriceConfig::PRICE_MODE_GROSS);
+
+        return (new CartChangeTransfer())
+            ->setQuote($quoteTransfer)
+            ->addItem((new ItemTransfer())->setSku($sku)->setQuantity(1));
+    }
+
+    public function getStoreTransfer(): StoreTransfer
+    {
+        return $this->getLocator()->store()->facade()->getStoreByName(static::STORE_NAME);
+    }
+
+    public function getCurrencyTransfer(): CurrencyTransfer
+    {
+        return $this->getLocator()->currency()->facade()->fromIsoCode(static::CURRENCY_ISO_CODE);
+    }
+}

--- a/tests/DemoTest/Zed/PriceCartConnector/codeception.yml
+++ b/tests/DemoTest/Zed/PriceCartConnector/codeception.yml
@@ -1,0 +1,32 @@
+namespace: DemoTest\Zed\PriceCartConnector
+
+paths:
+    tests: .
+    data: _data
+    support: _support
+    output: _output
+
+coverage:
+    enabled: true
+    remote: false
+    whitelist: { include: ['../../../../src/*'] }
+
+suites:
+    Business:
+        path: Business
+        actor: PriceCartConnectorBusinessTester
+        modules:
+            enabled:
+                - Asserts
+                - \PyzTest\Shared\Testify\Helper\Environment
+                - \SprykerTest\Shared\Testify\Helper\LocatorHelper:
+                    projectNamespaces: ['Demo', 'Pyz']
+                - \SprykerTest\Shared\Testify\Helper\ConfigHelper
+                - \SprykerTest\Shared\Testify\Helper\DataCleanupHelper
+                - \SprykerTest\Shared\Propel\Helper\TransactionHelper
+                - \SprykerTest\Shared\Testify\Helper\DependencyHelper
+                - \SprykerTest\Service\Container\Helper\ContainerHelper
+                - \SprykerTest\Shared\Store\Helper\StoreDependencyHelper
+                - \SprykerTest\Shared\Product\Helper\ProductDataHelper
+                - \SprykerTest\Shared\Currency\Helper\CurrencyDataHelper
+                - \SprykerTest\Shared\PriceProduct\Helper\PriceProductDataHelper

--- a/tests/DemoTest/Zed/PriceProduct/Business/PriceGrouperTest.php
+++ b/tests/DemoTest/Zed/PriceProduct/Business/PriceGrouperTest.php
@@ -1,0 +1,80 @@
+<?php
+
+/**
+ * This file is part of the Spryker Commerce OS.
+ * For full license information, please view the LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types = 1);
+
+namespace DemoTest\Zed\PriceProduct\Business;
+
+use Codeception\Test\Unit;
+use Demo\Shared\Price\PriceConfig;
+use DemoTest\Zed\PriceProduct\PriceProductBusinessTester;
+use Generated\Shared\Transfer\CurrencyTransfer;
+use Generated\Shared\Transfer\MoneyValueTransfer;
+use Generated\Shared\Transfer\PriceProductTransfer;
+use Generated\Shared\Transfer\PriceTypeTransfer;
+
+/**
+ * @group DemoTest
+ * @group Zed
+ * @group PriceProduct
+ * @group Business
+ * @group PriceGrouperTest
+ */
+class PriceGrouperTest extends Unit
+{
+    protected const string CURRENCY_CODE = 'EUR';
+
+    protected const string PRICE_TYPE_NAME = 'DEFAULT';
+
+    protected const int GROSS_AMOUNT = 10000;
+
+    protected const int NET_AMOUNT = 8403;
+
+    protected const int COST_AMOUNT = 6000;
+
+    protected PriceProductBusinessTester $tester;
+
+    public function testGroupPriceProductCollectionIncludesCostMode(): void
+    {
+        // Arrange
+        $priceProductTransfer = $this->createPriceProductTransfer(static::COST_AMOUNT);
+
+        // Act
+        $groupedPrices = $this->tester->getFacade()->groupPriceProductCollection([$priceProductTransfer]);
+
+        // Assert
+        $this->assertSame(
+            static::COST_AMOUNT,
+            $groupedPrices[static::CURRENCY_CODE][PriceConfig::PRICE_MODE_COST][static::PRICE_TYPE_NAME],
+        );
+    }
+
+    public function testGroupPriceProductCollectionOmitsCostModeWhenCostMissing(): void
+    {
+        // Arrange
+        $priceProductTransfer = $this->createPriceProductTransfer(null);
+
+        // Act
+        $groupedPrices = $this->tester->getFacade()->groupPriceProductCollection([$priceProductTransfer]);
+
+        // Assert
+        $this->assertArrayNotHasKey(PriceConfig::PRICE_MODE_COST, $groupedPrices[static::CURRENCY_CODE]);
+    }
+
+    private function createPriceProductTransfer(?int $costAmount): PriceProductTransfer
+    {
+        $moneyValueTransfer = (new MoneyValueTransfer())
+            ->setGrossAmount(static::GROSS_AMOUNT)
+            ->setNetAmount(static::NET_AMOUNT)
+            ->setCostAmount($costAmount)
+            ->setCurrency((new CurrencyTransfer())->setCode(static::CURRENCY_CODE));
+
+        return (new PriceProductTransfer())
+            ->setPriceType((new PriceTypeTransfer())->setName(static::PRICE_TYPE_NAME))
+            ->setMoneyValue($moneyValueTransfer);
+    }
+}

--- a/tests/DemoTest/Zed/PriceProduct/Business/PriceProductStoreWriterTest.php
+++ b/tests/DemoTest/Zed/PriceProduct/Business/PriceProductStoreWriterTest.php
@@ -1,0 +1,76 @@
+<?php
+
+/**
+ * This file is part of the Spryker Commerce OS.
+ * For full license information, please view the LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types = 1);
+
+namespace DemoTest\Zed\PriceProduct\Business;
+
+use Codeception\Test\Unit;
+use DemoTest\Zed\PriceProduct\PriceProductBusinessTester;
+use Orm\Zed\PriceProduct\Persistence\SpyPriceProductStoreQuery;
+
+/**
+ * @group DemoTest
+ * @group Zed
+ * @group PriceProduct
+ * @group Business
+ * @group PriceProductStoreWriterTest
+ */
+class PriceProductStoreWriterTest extends Unit
+{
+    protected const int GROSS_AMOUNT = 10000;
+
+    protected const int NET_AMOUNT = 8403;
+
+    protected const int COST_AMOUNT = 6000;
+
+    protected PriceProductBusinessTester $tester;
+
+    public function testCreatePriceForProductPersistsCostPriceToStore(): void
+    {
+        // Arrange
+        $productConcreteTransfer = $this->tester->haveProduct();
+
+        // Act
+        $priceProductTransfer = $this->tester->haveConcretePriceWithCost(
+            $productConcreteTransfer,
+            static::GROSS_AMOUNT,
+            static::NET_AMOUNT,
+            static::COST_AMOUNT,
+        );
+
+        // Assert
+        $costPrice = $this->findStoreCostPrice($priceProductTransfer->getIdPriceProduct());
+        $this->assertSame(static::COST_AMOUNT, $costPrice);
+    }
+
+    public function testCreatePriceForProductWithoutCostPersistsNullCostPrice(): void
+    {
+        // Arrange
+        $productConcreteTransfer = $this->tester->haveProduct();
+
+        // Act
+        $priceProductTransfer = $this->tester->haveConcretePriceWithCost(
+            $productConcreteTransfer,
+            static::GROSS_AMOUNT,
+            static::NET_AMOUNT,
+            null,
+        );
+
+        // Assert
+        $costPrice = $this->findStoreCostPrice($priceProductTransfer->getIdPriceProduct());
+        $this->assertNull($costPrice);
+    }
+
+    private function findStoreCostPrice(int $idPriceProduct): ?int
+    {
+        $priceProductStoreEntity = SpyPriceProductStoreQuery::create()
+            ->findOneByFkPriceProduct($idPriceProduct);
+
+        return $priceProductStoreEntity?->getCostPrice();
+    }
+}

--- a/tests/DemoTest/Zed/PriceProduct/Business/ReaderTest.php
+++ b/tests/DemoTest/Zed/PriceProduct/Business/ReaderTest.php
@@ -1,0 +1,118 @@
+<?php
+
+/**
+ * This file is part of the Spryker Commerce OS.
+ * For full license information, please view the LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types = 1);
+
+namespace DemoTest\Zed\PriceProduct\Business;
+
+use Codeception\Test\Unit;
+use Demo\Shared\Price\PriceConfig;
+use DemoTest\Zed\PriceProduct\PriceProductBusinessTester;
+use Generated\Shared\Transfer\PriceProductFilterTransfer;
+use Spryker\Shared\Price\PriceConfig as SprykerPriceConfig;
+
+/**
+ * @group DemoTest
+ * @group Zed
+ * @group PriceProduct
+ * @group Business
+ * @group ReaderTest
+ */
+class ReaderTest extends Unit
+{
+    protected const int GROSS_AMOUNT = 10000;
+
+    protected const int NET_AMOUNT = 8403;
+
+    protected const int COST_AMOUNT = 6000;
+
+    protected const string PRICE_TYPE_NAME = 'DEFAULT';
+
+    protected PriceProductBusinessTester $tester;
+
+    public function testFindPriceForCostModeReturnsCostAmount(): void
+    {
+        // Arrange
+        $productConcreteTransfer = $this->tester->haveProduct();
+        $this->tester->haveConcretePriceWithCost($productConcreteTransfer, static::GROSS_AMOUNT, static::NET_AMOUNT, static::COST_AMOUNT);
+        $priceProductFilterTransfer = $this->createFilter($productConcreteTransfer->getSku(), PriceConfig::PRICE_MODE_COST);
+
+        // Act
+        $price = $this->tester->getFacade()->findPriceFor($priceProductFilterTransfer);
+
+        // Assert
+        $this->assertSame(static::COST_AMOUNT, $price);
+    }
+
+    public function testFindPriceForNetModeReturnsNetAmount(): void
+    {
+        // Arrange
+        $productConcreteTransfer = $this->tester->haveProduct();
+        $this->tester->haveConcretePriceWithCost($productConcreteTransfer, static::GROSS_AMOUNT, static::NET_AMOUNT, static::COST_AMOUNT);
+        $priceProductFilterTransfer = $this->createFilter($productConcreteTransfer->getSku(), SprykerPriceConfig::PRICE_MODE_NET);
+
+        // Act
+        $price = $this->tester->getFacade()->findPriceFor($priceProductFilterTransfer);
+
+        // Assert
+        $this->assertSame(static::NET_AMOUNT, $price);
+    }
+
+    public function testFindPriceForGrossModeReturnsGrossAmount(): void
+    {
+        // Arrange
+        $productConcreteTransfer = $this->tester->haveProduct();
+        $this->tester->haveConcretePriceWithCost($productConcreteTransfer, static::GROSS_AMOUNT, static::NET_AMOUNT, static::COST_AMOUNT);
+        $priceProductFilterTransfer = $this->createFilter($productConcreteTransfer->getSku(), SprykerPriceConfig::PRICE_MODE_GROSS);
+
+        // Act
+        $price = $this->tester->getFacade()->findPriceFor($priceProductFilterTransfer);
+
+        // Assert
+        $this->assertSame(static::GROSS_AMOUNT, $price);
+    }
+
+    public function testConcreteWithoutCostInheritsAbstractCost(): void
+    {
+        // Arrange
+        $productConcreteTransfer = $this->tester->haveProduct();
+        $this->tester->haveAbstractPriceWithCost($productConcreteTransfer->getFkProductAbstract(), static::GROSS_AMOUNT, static::NET_AMOUNT, static::COST_AMOUNT);
+        $this->tester->haveConcretePriceWithCost($productConcreteTransfer, static::GROSS_AMOUNT, static::NET_AMOUNT, null);
+
+        // Act
+        $priceProductTransfers = $this->tester->getFacade()->findProductConcretePrices(
+            $productConcreteTransfer->getIdProductConcrete(),
+            $productConcreteTransfer->getFkProductAbstract(),
+        );
+
+        // Assert
+        $this->assertSame(static::COST_AMOUNT, $this->extractCostAmount($priceProductTransfers));
+    }
+
+    /**
+     * @param array<\Generated\Shared\Transfer\PriceProductTransfer> $priceProductTransfers
+     */
+    private function extractCostAmount(array $priceProductTransfers): ?int
+    {
+        foreach ($priceProductTransfers as $priceProductTransfer) {
+            if ($priceProductTransfer->getPriceTypeName() === static::PRICE_TYPE_NAME) {
+                return $priceProductTransfer->getMoneyValueOrFail()->getCostAmount();
+            }
+        }
+
+        return null;
+    }
+
+    private function createFilter(string $sku, string $priceMode): PriceProductFilterTransfer
+    {
+        return (new PriceProductFilterTransfer())
+            ->setSku($sku)
+            ->setPriceMode($priceMode)
+            ->setCurrencyIsoCode(PriceProductBusinessTester::CURRENCY_ISO_CODE)
+            ->setStoreName(PriceProductBusinessTester::STORE_NAME);
+    }
+}

--- a/tests/DemoTest/Zed/PriceProduct/_support/PriceProductBusinessTester.php
+++ b/tests/DemoTest/Zed/PriceProduct/_support/PriceProductBusinessTester.php
@@ -1,0 +1,84 @@
+<?php
+
+/**
+ * This file is part of the Spryker Commerce OS.
+ * For full license information, please view the LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types = 1);
+
+namespace DemoTest\Zed\PriceProduct;
+
+use Codeception\Actor;
+use Generated\Shared\Transfer\MoneyValueTransfer;
+use Generated\Shared\Transfer\PriceProductTransfer;
+use Generated\Shared\Transfer\ProductConcreteTransfer;
+
+/**
+ * Inherited Methods
+ *
+ * @method void wantToTest($text)
+ * @method void wantTo($text)
+ * @method void execute($callable)
+ * @method void expectTo($prediction)
+ * @method void expect($prediction)
+ * @method void amGoingTo($argumentation)
+ * @method void am($role)
+ * @method void lookForwardTo($achieveValue)
+ * @method void comment($description)
+ * @method \Codeception\Lib\Friend haveFriend($name, $actorClass = NULL)
+ * @method \Spryker\Zed\PriceProduct\Business\PriceProductFacadeInterface getFacade()
+ *
+ * @SuppressWarnings(\DemoTest\Zed\PriceProduct\PHPMD)
+ */
+class PriceProductBusinessTester extends Actor
+{
+    use _generated\PriceProductBusinessTesterActions;
+
+    public const string STORE_NAME = 'DE';
+
+    public const string CURRENCY_ISO_CODE = 'EUR';
+
+    public function haveConcretePriceWithCost(
+        ProductConcreteTransfer $productConcreteTransfer,
+        int $grossAmount,
+        int $netAmount,
+        ?int $costAmount,
+    ): PriceProductTransfer {
+        return $this->havePriceProduct([
+            PriceProductTransfer::SKU_PRODUCT_ABSTRACT => $productConcreteTransfer->getAbstractSku(),
+            PriceProductTransfer::SKU_PRODUCT => $productConcreteTransfer->getSku(),
+            PriceProductTransfer::ID_PRODUCT => $productConcreteTransfer->getIdProductConcrete(),
+            PriceProductTransfer::ID_PRODUCT_ABSTRACT => $productConcreteTransfer->getFkProductAbstract(),
+            PriceProductTransfer::MONEY_VALUE => $this->buildMoneyValueSeed($grossAmount, $netAmount, $costAmount),
+        ]);
+    }
+
+    public function haveAbstractPriceWithCost(
+        int $idProductAbstract,
+        int $grossAmount,
+        int $netAmount,
+        ?int $costAmount,
+    ): PriceProductTransfer {
+        return $this->havePriceProductAbstract($idProductAbstract, [
+            PriceProductTransfer::ID_PRODUCT_ABSTRACT => $idProductAbstract,
+            PriceProductTransfer::MONEY_VALUE => $this->buildMoneyValueSeed($grossAmount, $netAmount, $costAmount),
+        ]);
+    }
+
+    /**
+     * @param int $grossAmount
+     * @param int $netAmount
+     * @param int|null $costAmount
+     *
+     * @return array<string, int|null>
+     */
+    private function buildMoneyValueSeed(int $grossAmount, int $netAmount, ?int $costAmount): array
+    {
+        return [
+            MoneyValueTransfer::GROSS_AMOUNT => $grossAmount,
+            MoneyValueTransfer::NET_AMOUNT => $netAmount,
+            MoneyValueTransfer::COST_AMOUNT => $costAmount,
+        ];
+    }
+}

--- a/tests/DemoTest/Zed/PriceProduct/codeception.yml
+++ b/tests/DemoTest/Zed/PriceProduct/codeception.yml
@@ -1,0 +1,32 @@
+namespace: DemoTest\Zed\PriceProduct
+
+paths:
+    tests: .
+    data: _data
+    support: _support
+    output: _output
+
+coverage:
+    enabled: true
+    remote: false
+    whitelist: { include: ['../../../../src/*'] }
+
+suites:
+    Business:
+        path: Business
+        actor: PriceProductBusinessTester
+        modules:
+            enabled:
+                - Asserts
+                - \PyzTest\Shared\Testify\Helper\Environment
+                - \SprykerTest\Shared\Testify\Helper\LocatorHelper:
+                    projectNamespaces: ['Demo', 'Pyz']
+                - \SprykerTest\Shared\Testify\Helper\ConfigHelper
+                - \SprykerTest\Shared\Testify\Helper\DataCleanupHelper
+                - \SprykerTest\Shared\Propel\Helper\TransactionHelper
+                - \SprykerTest\Shared\Testify\Helper\DependencyHelper
+                - \SprykerTest\Service\Container\Helper\ContainerHelper
+                - \SprykerTest\Shared\Store\Helper\StoreDependencyHelper
+                - \SprykerTest\Shared\Product\Helper\ProductDataHelper
+                - \SprykerTest\Shared\Currency\Helper\CurrencyDataHelper
+                - \SprykerTest\Shared\PriceProduct\Helper\PriceProductDataHelper

--- a/tests/DemoTest/Zed/PriceProductDataImport/Business/PriceProductWriterStepTest.php
+++ b/tests/DemoTest/Zed/PriceProductDataImport/Business/PriceProductWriterStepTest.php
@@ -1,0 +1,60 @@
+<?php
+
+/**
+ * This file is part of the Spryker Commerce OS.
+ * For full license information, please view the LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types = 1);
+
+namespace DemoTest\Zed\PriceProductDataImport\Business;
+
+use Codeception\Test\Unit;
+use Demo\Zed\PriceProductDataImport\Business\Model\PriceProductWriterStep;
+use DemoTest\Zed\PriceProductDataImport\PriceProductDataImportBusinessTester;
+
+/**
+ * @group DemoTest
+ * @group Zed
+ * @group PriceProductDataImport
+ * @group Business
+ * @group PriceProductWriterStepTest
+ */
+class PriceProductWriterStepTest extends Unit
+{
+    protected const int GROSS_PRICE = 10000;
+
+    protected const int NET_PRICE = 8403;
+
+    protected const int COST_PRICE = 6000;
+
+    protected PriceProductDataImportBusinessTester $tester;
+
+    public function testExecutePersistsCostPriceToStore(): void
+    {
+        // Arrange
+        $productAbstractTransfer = $this->tester->haveProductAbstract();
+        $dataSet = $this->tester->createPriceProductDataSet($productAbstractTransfer, static::GROSS_PRICE, static::NET_PRICE, static::COST_PRICE);
+
+        // Act
+        (new PriceProductWriterStep())->execute($dataSet);
+
+        // Assert
+        $costPrice = $this->tester->findStoreCostPrice($productAbstractTransfer->getIdProductAbstract());
+        $this->assertSame(static::COST_PRICE, $costPrice);
+    }
+
+    public function testExecutePersistsNullCostPriceWhenCostEmpty(): void
+    {
+        // Arrange
+        $productAbstractTransfer = $this->tester->haveProductAbstract();
+        $dataSet = $this->tester->createPriceProductDataSet($productAbstractTransfer, static::GROSS_PRICE, static::NET_PRICE, null);
+
+        // Act
+        (new PriceProductWriterStep())->execute($dataSet);
+
+        // Assert
+        $costPrice = $this->tester->findStoreCostPrice($productAbstractTransfer->getIdProductAbstract());
+        $this->assertNull($costPrice);
+    }
+}

--- a/tests/DemoTest/Zed/PriceProductDataImport/_support/PriceProductDataImportBusinessTester.php
+++ b/tests/DemoTest/Zed/PriceProductDataImport/_support/PriceProductDataImportBusinessTester.php
@@ -1,0 +1,85 @@
+<?php
+
+/**
+ * This file is part of the Spryker Commerce OS.
+ * For full license information, please view the LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types = 1);
+
+namespace DemoTest\Zed\PriceProductDataImport;
+
+use Codeception\Actor;
+use Demo\Zed\PriceProductDataImport\Business\Model\DataSet\PriceProductDataSet;
+use Generated\Shared\Transfer\ProductAbstractTransfer;
+use Orm\Zed\PriceProduct\Persistence\SpyPriceProductStoreQuery;
+use Spryker\Zed\DataImport\Business\Model\DataSet\DataSet;
+
+/**
+ * Inherited Methods
+ *
+ * @method void wantToTest($text)
+ * @method void wantTo($text)
+ * @method void execute($callable)
+ * @method void expectTo($prediction)
+ * @method void expect($prediction)
+ * @method void amGoingTo($argumentation)
+ * @method void am($role)
+ * @method void lookForwardTo($achieveValue)
+ * @method void comment($description)
+ * @method \Codeception\Lib\Friend haveFriend($name, $actorClass = NULL)
+ *
+ * @SuppressWarnings(\DemoTest\Zed\PriceProductDataImport\PHPMD)
+ */
+class PriceProductDataImportBusinessTester extends Actor
+{
+    use _generated\PriceProductDataImportBusinessTesterActions;
+
+    public const string STORE_NAME = 'DE';
+
+    public const string CURRENCY_ISO_CODE = 'EUR';
+
+    public const string PRICE_TYPE_NAME = 'DEFAULT';
+
+    public const string PRICE_DATA = '[]';
+
+    public function createPriceProductDataSet(ProductAbstractTransfer $productAbstractTransfer, int $grossPrice, int $netPrice, ?int $costPrice): DataSet
+    {
+        $dataSet = new DataSet();
+        $dataSet[PriceProductDataSet::KEY_PRICE_TYPE] = static::PRICE_TYPE_NAME;
+        $dataSet[PriceProductDataSet::KEY_ABSTRACT_SKU] = $productAbstractTransfer->getSku();
+        $dataSet[PriceProductDataSet::KEY_CONCRETE_SKU] = '';
+        $dataSet[PriceProductDataSet::ID_PRODUCT_ABSTRACT] = $productAbstractTransfer->getIdProductAbstract();
+        $dataSet[PriceProductDataSet::ID_STORE] = $this->getIdStore();
+        $dataSet[PriceProductDataSet::ID_CURRENCY] = $this->getIdCurrency();
+        $dataSet[PriceProductDataSet::KEY_PRICE_GROSS] = $grossPrice;
+        $dataSet[PriceProductDataSet::KEY_PRICE_NET] = $netPrice;
+        $dataSet[PriceProductDataSet::KEY_PRICE_COST] = $costPrice === null ? '' : (string)$costPrice;
+        $dataSet[PriceProductDataSet::KEY_PRICE_DATA] = static::PRICE_DATA;
+        $dataSet[PriceProductDataSet::KEY_PRICE_DATA_CHECKSUM] = md5(sprintf('%d-%d-%s', $grossPrice, $netPrice, (string)$costPrice));
+
+        return $dataSet;
+    }
+
+    public function findStoreCostPrice(int $idProductAbstract): ?int
+    {
+        $priceProductStoreEntity = SpyPriceProductStoreQuery::create()
+            ->usePriceProductQuery()
+                ->filterByFkProductAbstract($idProductAbstract)
+            ->endUse()
+            ->filterByFkStore($this->getIdStore())
+            ->findOne();
+
+        return $priceProductStoreEntity?->getCostPrice();
+    }
+
+    public function getIdStore(): int
+    {
+        return $this->getLocator()->store()->facade()->getStoreByName(static::STORE_NAME)->getIdStore();
+    }
+
+    public function getIdCurrency(): int
+    {
+        return $this->getLocator()->currency()->facade()->fromIsoCode(static::CURRENCY_ISO_CODE)->getIdCurrency();
+    }
+}

--- a/tests/DemoTest/Zed/PriceProductDataImport/codeception.yml
+++ b/tests/DemoTest/Zed/PriceProductDataImport/codeception.yml
@@ -1,0 +1,32 @@
+namespace: DemoTest\Zed\PriceProductDataImport
+
+paths:
+    tests: .
+    data: _data
+    support: _support
+    output: _output
+
+coverage:
+    enabled: true
+    remote: false
+    whitelist: { include: ['../../../../src/*'] }
+
+suites:
+    Business:
+        path: Business
+        actor: PriceProductDataImportBusinessTester
+        modules:
+            enabled:
+                - Asserts
+                - \PyzTest\Shared\Testify\Helper\Environment
+                - \SprykerTest\Shared\Testify\Helper\LocatorHelper:
+                    projectNamespaces: ['Demo', 'Pyz']
+                - \SprykerTest\Shared\Testify\Helper\ConfigHelper
+                - \SprykerTest\Shared\Testify\Helper\DataCleanupHelper
+                - \SprykerTest\Shared\Propel\Helper\TransactionHelper
+                - \SprykerTest\Shared\Testify\Helper\DependencyHelper
+                - \SprykerTest\Service\Container\Helper\ContainerHelper
+                - \SprykerTest\Shared\Store\Helper\StoreDependencyHelper
+                - \SprykerTest\Shared\Product\Helper\ProductDataHelper
+                - \SprykerTest\Shared\Currency\Helper\CurrencyDataHelper
+                - \SprykerTest\Shared\PriceProduct\Helper\PriceProductDataHelper

--- a/tests/codeception.ci.functional.yml
+++ b/tests/codeception.ci.functional.yml
@@ -3,6 +3,7 @@ actor: Tester
 
 include:
     - PyzTest/*/*
+    - DemoTest/*/*
 
 paths:
     tests: .
@@ -21,7 +22,7 @@ coverage:
     enabled: true
     remote: true
     c3_url: 'http://backoffice.de.shop-suite.local'
-    whitelist: { include: ['src/Pyz/*.php'] }
+    whitelist: { include: ['src/Pyz/*.php', 'src/Demo/*.php'] }
 
 extensions:
     enabled:


### PR DESCRIPTION
## What

Stands up a `DemoTest` Codeception namespace (previously `src/Demo` had **zero** automated tests) and adds functional coverage for the highest-risk untested `src/Demo` logic, per the gap inventory for [CC-39427](https://spryker.atlassian.net/browse/CC-39427).

**Harness:** `DemoTest\` autoload-dev mapping, `test-autoload.php` resolver branch, `DemoTest/*/*` added to root + CI-functional codeception includes, `src/Demo/*.php` added to coverage whitelist.

**Tests (26 tests / 30 assertions, all green):**
- **Cost-price + gross-margin pricing chain (P1)** + cheap P2 — PriceProduct `Reader`/`PriceProductStoreWriter`/`PriceGrouper`, PriceCartConnector `PriceManager` (gross-denominator margin), Client `ProductPriceResolver` (net-denominator margin), `ProductGrossMargin` expander plugin, PriceProductDataImport writer step (`cost_price`).
- **CMS-block customer-group access control (P1)** + cheap P2 — `CmsBlockCustomerGroup` facade (validate access / save diff / get collection), `CmsBlockValidator` AND-aggregation, `CustomerGroup` collection mapping.

**Module completeness fix:** added the missing standard `CmsBlockCustomerGroupConfig` + `CmsBlockCustomerGroupDependencyProvider` (and resulting `getConfig()` factory annotations) for the Demo-only `CmsBlockCustomerGroup` Zed module so its facade resolves under Codeception. No runtime behavior change.

## Scope notes
AI Commerce 'Place Order' P1 and Merchant-Portal/catalog-search P2 deferred (per request).

## Verification
phpcs clean on touched files; phpstan/phpmd clean on new `src/`; `codecept build` discovers all 7 modules; all green locally.