### PR TITLE
CC-39427: enforce demo Cypress tests during master-demo reconciliation

### DIFF
--- a/.claude/skills/cypress-e2e-test/SKILL.md
+++ b/.claude/skills/cypress-e2e-test/SKILL.md
@@ -13,7 +13,7 @@ Cypress tests MUST follow Spryker conventions: mission-critical user journeys, P
 **Structure**: One test per distinct outcome. Group checks only when they represent a single user goal.
 **Data**: Use static fixtures for smoke tests; use dynamic fixtures (via API) for feature tests.
 **Page Objects**: All UI interactions go in page classes. Tests never use raw `cy.get()` selectors directly.
-**Repositories**: Selector logic lives in a dedicated interface file (`<feature>-repository.ts`) plus at least one implementation file in a `repositories/` subfolder (e.g. `repositories/suite-<feature>-repository.ts`). Never collapse these into a single concrete class — even when only suite is supported. See the Repositories section for the exact file layout.
+**Repositories**: Selector logic lives in a dedicated `<feature>-repository.ts`, never inline in the page. Choose the shape by how many demoshop variants the markup actually has — **one concrete `@injectable @autoWired` class injected by its class token** when a single implementation covers every shop (the common case), OR an **interface + per-shop impls in `repositories/`** bound via a `REPOSITORIES` token only when the markup genuinely differs per demoshop. Do NOT default to the interface split — it was rejected on review (PR #330) as needless indirection for single-impl features. See the Repositories section for the decision rule and both layouts.
 **DI**: Use `container.get(PageClass)` for all page and scenario instances — never `new`.
 **Naming**: camelCase for variables/functions, PascalCase for classes, kebab-case for files. No abbreviations — write `authentication`, not `auth`.
 **Reuse**: Search existing pages, scenarios, commands, and fixtures before creating anything new. Priority: Reuse > Update > Create.
@@ -205,7 +205,7 @@ function getPaymentMethod(): string {
 **Location**: `tests/cypress-tests/cypress/support/pages/{yves|backoffice|mp}/`
 
 ```typescript
-import { autoWired, REPOSITORIES } from '@utils';
+import { autoWired } from '@utils';
 import { inject, injectable } from 'inversify';
 import { YvesPage } from '@pages/yves';
 import { FeatureRepository } from './feature-repository';
@@ -213,7 +213,10 @@ import { FeatureRepository } from './feature-repository';
 @injectable()
 @autoWired
 export class FeaturePage extends YvesPage {
-  @inject(REPOSITORIES.FeatureRepository) private repository: FeatureRepository;
+  // Single-impl (common case): inject the concrete repository by its CLASS token.
+  // Multi-variant only: `import { ..., REPOSITORIES } from '@utils'` and
+  // `@inject(REPOSITORIES.FeatureRepository) private repository: FeatureRepository;`
+  @inject(FeatureRepository) private repository: FeatureRepository;
 
   protected PAGE_URL = '/feature-path';
 
@@ -235,43 +238,31 @@ export class FeaturePage extends YvesPage {
 
 ## Repositories (Selector Logic)
 
-**This pattern is the single most-skipped rule. Pay extra attention.** Selector code MUST NOT live in the page class; it MUST be split into an **interface file** and a **per-demoshop implementation file** injected via DI. Why: selectors drift between demoshop variants (suite / b2b / b2b-mp render slightly different markup), and the interface is the contract that lets us swap a variant without rewriting the page or the test. A single concrete repository class collapses that flexibility and breaks the pattern.
+Selector code MUST NOT live in the page class — it lives in a `<feature>-repository.ts` injected via DI. **Which of the two shapes you use depends on whether the markup genuinely differs per demoshop.** Picking the wrong shape is reviewable both ways: inlining selectors in the page is wrong, and so is wrapping a single implementation in an interface + `REPOSITORIES` token + multi-map binding (rejected on PR #330 as dead indirection — `Suite`-prefixing a class that is the *only* impl reads as "there are other variants" when there aren't).
 
-### Required file layout
+### Decision rule — read this before creating files
+
+- **One implementation covers every demoshop** (the common case — most features render identical markup everywhere): a **single concrete class** named `<Feature>Repository`, `@injectable @autoWired`, injected into the page by its **class token** (`@inject(FeatureRepository)`). No interface, no `repositories/` subfolder, no `REPOSITORIES` entry, no binding map. This is exactly how the existing `ConfigurationRepository` works — mirror it.
+- **The markup genuinely differs per demoshop** (suite vs b2b vs b2b-mp render different DOM, e.g. `MultiFactorAuth`): an **interface** `<Feature>Repository` + one impl per shop under `repositories/` (`suite-…`, `b2b-…`, `b2b-mp-…`), bound through a `REPOSITORIES.<X>` token. The interface is the contract that lets DI swap the variant.
+
+When unsure, start with the single concrete class. Promoting it to an interface later — *if* a second real variant appears — is a small, mechanical change; you are not locked in.
+
+### Common case — single concrete class (DEFAULT)
 
 ```
 cypress/support/pages/<layer>/<feature>/
-├── <feature>-page.ts                       ← the Page class (injects the repository)
-├── <feature>-repository.ts                 ← the INTERFACE — selector contract
-└── repositories/
-    └── suite-<feature>-repository.ts       ← the suite IMPLEMENTATION
-    └── b2b-<feature>-repository.ts         ← (optional, only if user confirmed in Discovery)
-    └── b2b-mp-<feature>-repository.ts      ← (optional, only if user confirmed in Discovery)
+├── <feature>-page.ts                       ← Page class; `@inject(FeatureRepository)`
+└── <feature>-repository.ts                 ← the concrete repository (selectors live here)
 ```
 
-### Interface file — `<feature>-repository.ts`
-
-Must declare `export interface`, one getter per selector, no implementations.
-
 ```typescript
-export interface FeatureRepository {
-  getNameInput(): Cypress.Chainable;
-  getEmailInput(): Cypress.Chainable;
-  getSubmitButton(): Cypress.Chainable;
-  getSuccessMessageSelector(): string;
-}
-```
-
-### Suite implementation file — `repositories/suite-<feature>-repository.ts`
-
-Must live inside the `repositories/` subfolder, must `implements FeatureRepository`, must be `@injectable`, must use `[data-qa="..."]` selectors.
-
-```typescript
+// <feature>-repository.ts
+import { autoWired } from '@utils';
 import { injectable } from 'inversify';
-import { FeatureRepository } from '../<feature>-repository';
 
 @injectable()
-export class SuiteFeatureRepository implements FeatureRepository {
+@autoWired
+export class FeatureRepository {
   getNameInput = (): Cypress.Chainable => cy.get('[data-qa="feature-name-input"]');
   getEmailInput = (): Cypress.Chainable => cy.get('[data-qa="feature-email-input"]');
   getSubmitButton = (): Cypress.Chainable => cy.get('[data-qa="feature-submit-button"]');
@@ -279,44 +270,56 @@ export class SuiteFeatureRepository implements FeatureRepository {
 }
 ```
 
-### ❌ Anti-pattern — DO NOT DO THIS
+`@autoWired` self-binds the class (`container.bind(FeatureRepository).toSelf()`), so `@inject(FeatureRepository)` in the page resolves with **no** entry in `types.ts` or `inversify.config.ts`. Don't add one.
 
-A single concrete class with selectors inlined:
+### Variant case — interface + per-shop impls (ONLY when markup differs)
+
+```
+cypress/support/pages/<layer>/<feature>/
+├── <feature>-page.ts                       ← `@inject(REPOSITORIES.FeatureRepository)`
+├── <feature>-repository.ts                 ← the INTERFACE (selector contract)
+└── repositories/
+    ├── suite-<feature>-repository.ts       ← `implements FeatureRepository`, @injectable
+    ├── b2b-<feature>-repository.ts
+    └── b2b-mp-<feature>-repository.ts
+```
+
 ```typescript
-// BAD: violates the interface+variant pattern
+// <feature>-repository.ts  (interface — no implementations)
+export interface FeatureRepository {
+  getNameInput(): Cypress.Chainable;
+  getSubmitButton(): Cypress.Chainable;
+}
+// repositories/suite-<feature>-repository.ts
+import { injectable } from 'inversify';
+import { FeatureRepository } from '../<feature>-repository';
+
 @injectable()
-export class FeatureRepository {
+export class SuiteFeatureRepository implements FeatureRepository {
   getNameInput = (): Cypress.Chainable => cy.get('[data-qa="feature-name-input"]');
-  // …
+  getSubmitButton = (): Cypress.Chainable => cy.get('[data-qa="feature-submit-button"]');
 }
 ```
 
-This is the most common failure mode — don't collapse the interface and impl into one class, even when only suite is supported. The interface still matters because:
-- DI uses `REPOSITORIES.FeatureRepository` as a `Symbol.for(...)` token — the interface is what's bound.
-- Future demoshop variants become a 30-line addition rather than a refactor of every consumer.
+Then add the token to `types.ts` and bind the right impl in EACH demoshop map in `inversify.config.ts`:
+```typescript
+// types.ts
+export const REPOSITORIES = { /* …existing */ FeatureRepository: Symbol.for('FeatureRepository') };
+// inversify.config.ts — per demoshop map, the variant that matches that shop's markup
+[REPOSITORIES.FeatureRepository]: SuiteFeatureRepository,   // suite map
+[REPOSITORIES.FeatureRepository]: B2bMpFeatureRepository,   // b2b-mp map
+```
 
-### Selector priority
+### Selector priority (both shapes)
 
 1. `[data-qa="..."]` — always preferred
 2. `id` attribute — `[id="setting-key"]` if no `data-qa`
 3. `name` attribute — `[name="field_name"]` for form fields without `data-qa`
-4. Never use CSS classes, nth-child, or text matching
+4. Last resort, when a core/partial exposes none of the above: stable layout structure (`.page-title-head h2`, `[data-qa="title-action"]`) or the partial's translated text. Keep these selectors self-evident from their getter name — do NOT add explanatory doc-block comments (reviewers asked for them removed on PR #330; the getter name is the documentation).
 
-### DI binding
+### Comments in test code
 
-After creating the two files, register in `cypress/support/utils/inversify/inversify.config.ts`:
-
-```typescript
-container.bind(REPOSITORIES.FeatureRepository).to(SuiteFeatureRepository).inSingletonScope();
-```
-
-And add the token to `types.ts`:
-```typescript
-export const REPOSITORIES = {
-  // …existing
-  FeatureRepository: Symbol.for('FeatureRepository'),
-};
-```
+Reviewers (PR #330) explicitly objected to verbose `/** … */` headers on specs, pages, and repositories. Keep test code comment-free: a well-named `it(...)`, page method, and selector getter say what a comment would. Put any "what does this test cover" narrative in the `it(...)` description, not a file header.
 
 ---
 
@@ -430,28 +433,11 @@ Always define typed interfaces — never use `any` for fixture data.
 
 ## Inversify DI Registration
 
-After adding a new page, repository, or scenario, register it in:
+`@autoWired` self-binds any class decorated with it (`container.bind(Class).toSelf()`), so classes injected by their **own class token** need NO manual registration. This covers:
+- Pages (`@inject(...)` consumers) and scenarios — already `@autoWired`, just `container.get(Page)` them.
+- **Single-impl repositories** (the default shape) — `@injectable @autoWired class FeatureRepository`, injected as `@inject(FeatureRepository)`. Do **not** add it to `types.ts` or `inversify.config.ts`.
 
-**File**: `tests/cypress-tests/cypress/support/utils/inversify/inversify.config.ts`
-
-```typescript
-import { SuiteFeatureRepository } from '../../pages/yves/feature/repositories/suite-feature-repository';
-import { FeaturePage } from '../../pages/yves/feature/feature-page';
-import { FeatureScenario } from '../../scenarios/yves/feature-scenario';
-
-container.bind(REPOSITORIES.FeatureRepository).to(SuiteFeatureRepository).inSingletonScope();
-container.bind(FeaturePage).to(FeaturePage).inSingletonScope();
-container.bind(FeatureScenario).to(FeatureScenario).inSingletonScope();
-```
-
-Add the repository token to `types.ts`:
-
-```typescript
-export const REPOSITORIES = {
-  // existing...
-  FeatureRepository: Symbol.for('FeatureRepository'),
-};
-```
+You only touch the central DI files for the **variant repository shape** — register the `REPOSITORIES.<X>` token in `types.ts` and bind the per-shop impl in each demoshop map in `inversify.config.ts` (see the Repositories "Variant case" above). If you find yourself binding the same single class into every map, you're using the wrong shape — collapse it to a self-bound concrete class.
 
 ---
 

--- a/.claude/skills/cypress-e2e-test/SKILL.md
+++ b/.claude/skills/cypress-e2e-test/SKILL.md
@@ -546,6 +546,12 @@ cy.reloadUntilFound(url, selector, parentSelector, retries, wait)
 
 ## Running Tests
 
+> ⚠️ **`tests/cypress-tests/.env` must exist, or every run dies before a single test with `Expected e2e.baseUrl to be a fully qualified URL … the value was "undefined://"`.** The config builds host/protocol from env vars loaded via `dotenv` from `.env`; with no `.env` they're `undefined`. `.env` is git-ignored, so it is NOT in a fresh checkout — and it gets **wiped whenever composer reinstalls the package** (`composer update spryker/cypress-tests` prints "The .git directory is missing… reinstalling", then removes + re-clones `tests/cypress-tests/`, taking `.env` and any other uncommitted file with it). After any such reinstall, or on a clean checkout, recreate it from the example that matches your stack — for this repo (b2b-mp on `.eu.spryker.local`) that's the dynamic-store example, which is also what CI uses:
+> ```bash
+> cd tests/cypress-tests && cp .env.dynamic-store.example .env
+> ```
+> Note the example sets `ENV_REPOSITORY_ID=suite`. A demoshop-guarded spec (e.g. the `demo` group, guarded to `b2b-mp`) will then **skip** on a bare `npm run …`. Prefix the real repo id to actually exercise it: `ENV_REPOSITORY_ID=b2b-mp ENV_IS_SSP_ENABLED=true npm run cy:demo`. (CI passes these via `docker/sdk exec --env`, so CI is unaffected.)
+
 **Open interactive runner:**
 ```bash
 cd tests/cypress-tests && npx cypress open

--- a/.claude/skills/cypress-e2e-test/SKILL.md
+++ b/.claude/skills/cypress-e2e-test/SKILL.md
@@ -98,7 +98,11 @@ tests/cypress-tests/cypress/e2e/
 features that ship only in `master-demo`). It must be runnable on its own and must NOT be swept up by
 any other run:
 
-- **Command**: `npm run cy:demo` → `cypress run --spec "cypress/e2e/demo/**/*.ts" --headless --browser chrome`
+- **Command**: `npm run cy:demo`. In this repo the script **self-pins** the demoshop:
+  `ENV_REPOSITORY_ID=b2b-mp cypress run --spec "cypress/e2e/demo/**/*.ts" --headless --browser chrome`.
+  So a bare `npm run cy:demo` Just Works from any shell regardless of what `.env` defaults to — no env
+  prefix needed. (CI injects `ENV_REPOSITORY_ID` via `docker/sdk exec --env`, which agrees with the
+  self-pin, so CI is unaffected.)
 - **Excluded everywhere else**: the other globs use `!(smoke|demo)` so `cy:ci` and `cy:run` skip it;
   `cy:smoke` only matches `smoke/**`. Do NOT touch `cy:ci:ssp` for this — its filename filter `(ssp)*`
   already excludes demo specs (use plain feature filenames, never an `ssp`-prefixed one, under `demo/`).
@@ -106,10 +110,15 @@ any other run:
   own step in the Cypress/UI job, mirroring the SSP step — its failures are reported independently.
 - **Tags**: use `@demo` as the layer tag (plus a `@<feature>` tag and a real module tag). Static fixtures
   only, same as smoke — no dynamic fixtures, no CLI commands, no AI-provider calls.
-- **Fixtures**: `fixtures/{repositoryId}/demo/<feature>/static-<feature>.json`.
+- **Fixtures**: `fixtures/b2b-mp/demo/static-<feature>.json` (the spec sits directly in `demo/`, so the
+  fixture dir is `demo/` — NO extra `<feature>/` subfolder; see the fixture auto-discovery warning).
 - **Types**: `support/types/demo/index.ts` (re-export per-feature interface files), aliased as `@interfaces/demo`.
-- **Guard** non-b2b-mp repos at the top of the `describe` with `it.skip(...)` + `return`, since the demo
-  features only ship in `b2b-mp`.
+- **No `repositoryId` guard.** Earlier demo specs guarded the `describe` with
+  `if (!['b2b-mp'].includes(Cypress.env('repositoryId'))) { it.skip(...); return; }`. That guard was
+  REMOVED (PR #330) — the demo command self-pins b2b-mp, fixtures resolve under `fixtures/b2b-mp/demo/`,
+  and the `demo/` glob is excluded from every other run, so nothing else ever loads these specs. Adding
+  the guard back is dead code. (Only re-introduce a guard if a demo spec is ever expected to be swept up
+  by a multi-repo run — which the current isolation makes impossible.)
 
 ---
 
@@ -511,7 +520,7 @@ All three must pass before the task is complete.
 ENV_REPOSITORY_ID=b2b-mp npx cypress run --spec "cypress/e2e/<group>/<feature>.cy.ts" --headless --browser chrome
 ```
 
-If the spec is guarded to a single demoshop, also run it under a different `ENV_REPOSITORY_ID` to confirm it **skips cleanly** (pending, not erroring) rather than throwing during DI/`container.get` resolution.
+If the spec uses a `repositoryId` guard (the variant pattern, not the demo group — which is unguarded), also run it under a different `ENV_REPOSITORY_ID` to confirm it **skips cleanly** (pending, not erroring) rather than throwing during DI/`container.get` resolution.
 
 ---
 
@@ -536,7 +545,7 @@ cy.reloadUntilFound(url, selector, parentSelector, retries, wait)
 > ```bash
 > cd tests/cypress-tests && cp .env.dynamic-store.example .env
 > ```
-> Note the example sets `ENV_REPOSITORY_ID=suite`. A demoshop-guarded spec (e.g. the `demo` group, guarded to `b2b-mp`) will then **skip** on a bare `npm run …`. Prefix the real repo id to actually exercise it: `ENV_REPOSITORY_ID=b2b-mp ENV_IS_SSP_ENABLED=true npm run cy:demo`. (CI passes these via `docker/sdk exec --env`, so CI is unaffected.)
+> Note the example sets `ENV_REPOSITORY_ID=suite`. For the **layer** runs (`cy:ci:*`, `cy:smoke`) that default decides which demoshop's fixtures/markup are exercised — prefix `ENV_REPOSITORY_ID=<shop>` to target another. The **`cy:demo`** script self-pins `ENV_REPOSITORY_ID=b2b-mp`, so it ignores the `.env` default and runs the demo specs against b2b-mp with no prefix. (CI passes env via `docker/sdk exec --env`, unaffected either way.)
 
 **Open interactive runner:**
 ```bash
@@ -572,6 +581,7 @@ cd tests/cypress-tests && npx cypress run --env grepTags="@checkout" --headless 
 
 ## Directory Structure for a New Feature
 
+Default shape (single-impl repository — most features):
 ```
 cypress/
 ├── e2e/yves/feature-name/
@@ -581,15 +591,14 @@ cypress/
 │   └── dynamic-feature-name.json
 └── support/
     ├── pages/yves/feature-name/
-    │   ├── feature-name-page.ts
-    │   ├── feature-name-repository.ts
-    │   └── repositories/
-    │       └── suite-feature-name-repository.ts
+    │   ├── feature-name-page.ts          (@inject(FeatureNameRepository))
+    │   └── feature-name-repository.ts    (concrete @injectable @autoWired class)
     ├── scenarios/yves/
     │   └── feature-name-scenario.ts
     └── types/yves/
         └── index.ts  (add interface exports here)
 ```
+Only when markup differs per demoshop, add the interface + `repositories/<shop>-…` impls + `REPOSITORIES` token (see Repositories "Variant case").
 
 ## Checklist for a New Feature Test
 
@@ -597,9 +606,9 @@ cypress/
 1. Create static fixture JSON (always required) — start with `suite` under `fixtures/suite/<layer>/<feature>/`
 2. Create dynamic fixture JSON (if entities need to be created) — same suite-first rule
 3. Define TypeScript interfaces for both fixtures
-4. Create the repository interface and a **`suite`** implementation first. Only add `b2b` / `b2b-mp` implementations if the user confirmed the feature ships in those demoshops during discovery — otherwise, flag it as a follow-up in your final summary
-5. Create the page class extending the correct base page
+4. Create the repository. **Default: one concrete `@injectable @autoWired class <Feature>Repository`** with the selectors. Only split into an interface + per-shop impls under `repositories/` if you confirmed during discovery that the markup genuinely differs across demoshops — otherwise the single class is correct and complete
+5. Create the page class extending the correct base page; inject the repository by its class token (`@inject(<Feature>Repository)`) for the default shape
 6. Create a scenario class if the flow spans multiple pages
-7. Register all bindings in `inversify.config.ts` and `types.ts`
-8. Write the test file with `describe` tags and `before()` fixture loading
-9. Run the test to verify it passes
+7. DI: nothing to register for the default shape (`@autoWired` self-binds). Only the variant shape adds a `REPOSITORIES` token to `types.ts` + per-map bindings in `inversify.config.ts`
+8. Write the test file with `describe` tags and `before()` fixture loading. No file-header doc-blocks — intent goes in the `it(...)` names
+9. Run the test live to verify it passes — static gates (typecheck/lint/prettier) do NOT prove it works

--- a/.claude/skills/cypress-e2e-test/SKILL.md
+++ b/.claude/skills/cypress-e2e-test/SKILL.md
@@ -1,0 +1,613 @@
+---
+name: cypress-e2e-test
+description: Use the skill to create, update, fix, edit or run Cypress E2E tests in "tests/cypress-tests/**" ensures tests follow Spryker standards and best practices
+---
+
+**Testing rule**
+Cypress tests MUST follow Spryker conventions: mission-critical user journeys, Page Object Model with repository pattern, Inversify DI, fixture-based data, and tag-based filtering.
+
+## Critical Instructions
+
+**Scope**: Test end-to-end user flows across Storefront (Yves), Backoffice (Zed), Merchant Portal (MP), and API layers.
+**Focus**: Happy-path journeys, representative error cases, and cross-interface effects — NOT UI styling, backend logic, or edge cases.
+**Structure**: One test per distinct outcome. Group checks only when they represent a single user goal.
+**Data**: Use static fixtures for smoke tests; use dynamic fixtures (via API) for feature tests.
+**Page Objects**: All UI interactions go in page classes. Tests never use raw `cy.get()` selectors directly.
+**Repositories**: Selector logic lives in a dedicated interface file (`<feature>-repository.ts`) plus at least one implementation file in a `repositories/` subfolder (e.g. `repositories/suite-<feature>-repository.ts`). Never collapse these into a single concrete class — even when only suite is supported. See the Repositories section for the exact file layout.
+**DI**: Use `container.get(PageClass)` for all page and scenario instances — never `new`.
+**Naming**: camelCase for variables/functions, PascalCase for classes, kebab-case for files. No abbreviations — write `authentication`, not `auth`.
+**Reuse**: Search existing pages, scenarios, commands, and fixtures before creating anything new. Priority: Reuse > Update > Create.
+
+---
+
+## Discovery — Run this FIRST
+
+Before writing any test, discover the feature's UI surface and confirm the journey list with the user. Skipping this step leads to tests that miss critical flows or duplicate existing coverage.
+
+**Step 1 — Locate feature sources:**
+- Module code: grep `src/Spryker/<FeatureName>`, `src/SprykerFeature/<FeatureName>`, `src/SprykerShop/<FeatureName>`
+- Yves templates: `src/**/Yves/**/Theme/**/*.twig`
+- Backoffice templates: `src/**/Zed/**/Presentation/**/*.twig`
+- Controllers + routes: `src/**/{Yves,Zed}/**/Controller/*Controller.php`
+- Existing cypress coverage: `tests/cypress-tests/cypress/e2e/**/*<feature>*`, `tests/cypress-tests/cypress/support/pages/**/<feature>*`
+
+**Step 2 — Read the PRD if one exists:**
+- Check `resources/plan/PRD/Features/<FeatureName>/` for a `*.prd.md` file
+- Extract user stories and acceptance-criteria Gherkin scenarios — these map almost 1:1 to `it(...)` blocks
+
+**Step 3 — Present a journey list to the user for confirmation.** Format:
+```
+Feature: <name>
+Layer(s) detected: Yves / Backoffice / MP
+Proposed test journeys:
+  1. <Main success flow from AC 1.1>
+  2. <Validation or error path from AC 1.2>
+  3. <Role-specific variation from AC X>
+Demoshops to cover: [suite] (default) — add b2b / b2b-mp?
+Existing cypress coverage found: <list or "none">
+```
+
+Wait for user sign-off (or adjustments) before generating files. If a PRD has 10+ user stories, pick the 3–5 most critical happy-path + error journeys — don't try to cover every Gherkin scenario.
+
+---
+
+## What to Cover
+
+- Mission-critical happy paths: login, checkout, registration, order management
+- Key error/validation cases (1–2 per feature): missing field, invalid input, duplicate entry
+- Cross-interface flows: MP configuration → storefront display, Zed update → MP status
+- Role-specific journeys: guest vs. authenticated customer, merchant on MP, admin on Zed
+- API endpoints: at least one positive and one negative user journey with schema validation
+
+## What NOT to Cover
+
+- Visual styles, colors, fonts, layout, pixel-perfect checks
+- Exhaustive validation-rule combinations (that belongs in unit/functional tests)
+- Complex data relationships or database state validation
+- Backend business logic in isolation
+- Rarely used features or internal tools (unless mission-critical)
+- Highly dynamic or randomized content
+- Third-party sites or services you do not control
+- Flows already covered at the unit or functional test level
+
+### Scenario count guidance
+
+- 1 test — main success flow
+- 1–2 tests — key validation or error paths
+- +1 test per distinct role/interface variation (only when behavior differs)
+
+---
+
+## Test File Location & Naming
+
+```
+tests/cypress-tests/cypress/e2e/
+├── smoke/          # Static fixtures only, no CLI commands
+├── demo/           # Isolated demo-only group (this repo) — runs ONLY via `npm run cy:demo`
+├── yves/           # Storefront feature tests
+├── backoffice/     # Backoffice feature tests
+├── mp/             # Merchant Portal feature tests
+└── api/            # API endpoint tests
+```
+
+**File name**: `{feature-name}.cy.ts` — e.g. `basic-checkout.cy.ts`, `product-attachment-management.cy.ts`
+
+### The `demo` group (this repository, master-demo)
+
+`cypress/e2e/demo/` is an **isolated** group for demo-shop-only feature coverage (e.g. the AI Commerce
+features that ship only in `master-demo`). It must be runnable on its own and must NOT be swept up by
+any other run:
+
+- **Command**: `npm run cy:demo` → `cypress run --spec "cypress/e2e/demo/**/*.ts" --headless --browser chrome`
+- **Excluded everywhere else**: the other globs use `!(smoke|demo)` so `cy:ci` and `cy:run` skip it;
+  `cy:smoke` only matches `smoke/**`. Do NOT touch `cy:ci:ssp` for this — its filename filter `(ssp)*`
+  already excludes demo specs (use plain feature filenames, never an `ssp`-prefixed one, under `demo/`).
+- **CI**: a dedicated `Run Tests (Demo)` step (id `run_demo_tests`, `if: always()`) runs `cy:demo` as its
+  own step in the Cypress/UI job, mirroring the SSP step — its failures are reported independently.
+- **Tags**: use `@demo` as the layer tag (plus a `@<feature>` tag and a real module tag). Static fixtures
+  only, same as smoke — no dynamic fixtures, no CLI commands, no AI-provider calls.
+- **Fixtures**: `fixtures/{repositoryId}/demo/<feature>/static-<feature>.json`.
+- **Types**: `support/types/demo/index.ts` (re-export per-feature interface files), aliased as `@interfaces/demo`.
+- **Guard** non-b2b-mp repos at the top of the `describe` with `it.skip(...)` + `return`, since the demo
+  features only ship in `b2b-mp`.
+
+---
+
+## Test Structure
+
+```typescript
+import { container } from '@utils';
+import { FeatureStaticFixtures, FeatureDynamicFixtures } from '@interfaces/yves';
+import { SomePage, AnotherPage } from '@pages/yves';
+import { SomeScenario } from '@scenarios/yves';
+
+describe('feature name', { tags: ['@yves', '@feature-name', 'feature-name', 'spryker-core'] }, (): void => {
+  const somePage = container.get(SomePage);
+  const someScenario = container.get(SomeScenario);
+
+  let staticFixtures: FeatureStaticFixtures;
+  let dynamicFixtures: FeatureDynamicFixtures;
+
+  before((): void => {
+    ({ staticFixtures, dynamicFixtures } = Cypress.env());
+  });
+
+  beforeEach((): void => {
+    // Login or session setup if required per test
+  });
+
+  it('user should be able to complete the main success flow', (): void => {
+    somePage.visit();
+    someScenario.execute({ param: dynamicFixtures.entity });
+
+    cy.contains(somePage.getSuccessMessage()).should('be.visible');
+  });
+
+  it('user should see validation error when required field is missing', (): void => {
+    somePage.visit();
+    somePage.submitEmptyForm();
+
+    cy.contains('Field is required').should('be.visible');
+  });
+});
+```
+
+**Key rules**:
+- Always destructure both `staticFixtures` and `dynamicFixtures` from `Cypress.env()` in `before()`
+- Use `beforeEach()` for per-test login via scenario — never manually repeat login steps in each test
+- Use helper functions inside `describe` for repeated interaction sequences
+- Never use `cy.get()` directly in test files — always go through a page object
+
+---
+
+## Tags
+
+Every `describe()` block MUST include tags:
+
+```typescript
+{ tags: ['@smoke', '@checkout', 'checkout', 'spryker-core'] }
+```
+
+**Layer tags**: `@smoke`, `@yves`, `@backoffice`, `@mp`, `@api`
+**Feature tags**: `@feature-name` (with `@`) + `feature-name` (without `@`) — include both
+**Module tags**: `spryker-core`, `spryker-core-back-office`, `marketplace-merchantportal-core`
+
+**Critical**: Tags without `@` prefix MUST match actual feature repository names from `github.com/spryker-feature`. Do NOT invent or guess these tags — they are used for contextual test execution in the Release App.
+
+---
+
+## Repository-Aware Test Skipping
+
+```typescript
+// Skip for specific demoshops at describe level
+if (['b2c', 'b2b'].includes(Cypress.env('repositoryId'))) {
+  it.skip('skipped because tests run only for suite, b2b-mp and b2c-mp', () => {});
+  return;
+}
+
+// Skip a single test using a helper function
+function skipB2BIt(description: string, testFn: () => void): void {
+  (['b2b', 'b2b-mp'].includes(Cypress.env('repositoryId')) ? it.skip : it)(description, testFn);
+}
+
+// Select value based on demoshop
+function getPaymentMethod(): string {
+  return ['b2c-mp', 'b2b-mp'].includes(Cypress.env('repositoryId'))
+    ? 'dummyMarketplacePaymentInvoice'
+    : 'dummyPaymentInvoice';
+}
+```
+
+---
+
+## Page Objects
+
+**Location**: `tests/cypress-tests/cypress/support/pages/{yves|backoffice|mp}/`
+
+```typescript
+import { autoWired, REPOSITORIES } from '@utils';
+import { inject, injectable } from 'inversify';
+import { YvesPage } from '@pages/yves';
+import { FeatureRepository } from './feature-repository';
+
+@injectable()
+@autoWired
+export class FeaturePage extends YvesPage {
+  @inject(REPOSITORIES.FeatureRepository) private repository: FeatureRepository;
+
+  protected PAGE_URL = '/feature-path';
+
+  submitForm = (params: { name: string; email: string }): void => {
+    this.repository.getNameInput().type(params.name);
+    this.repository.getEmailInput().type(params.email);
+    this.repository.getSubmitButton().click();
+  };
+
+  getSuccessMessage = (): string => 'Successfully saved';
+}
+```
+
+- Extend `YvesPage`, `BackofficePage`, or `AbstractPage` depending on layer
+- Methods return `void` or `Cypress.Chainable` — never raw DOM values
+- No `cy.get()` calls inside page classes — delegate to the repository
+
+---
+
+## Repositories (Selector Logic)
+
+**This pattern is the single most-skipped rule. Pay extra attention.** Selector code MUST NOT live in the page class; it MUST be split into an **interface file** and a **per-demoshop implementation file** injected via DI. Why: selectors drift between demoshop variants (suite / b2b / b2b-mp render slightly different markup), and the interface is the contract that lets us swap a variant without rewriting the page or the test. A single concrete repository class collapses that flexibility and breaks the pattern.
+
+### Required file layout
+
+```
+cypress/support/pages/<layer>/<feature>/
+├── <feature>-page.ts                       ← the Page class (injects the repository)
+├── <feature>-repository.ts                 ← the INTERFACE — selector contract
+└── repositories/
+    └── suite-<feature>-repository.ts       ← the suite IMPLEMENTATION
+    └── b2b-<feature>-repository.ts         ← (optional, only if user confirmed in Discovery)
+    └── b2b-mp-<feature>-repository.ts      ← (optional, only if user confirmed in Discovery)
+```
+
+### Interface file — `<feature>-repository.ts`
+
+Must declare `export interface`, one getter per selector, no implementations.
+
+```typescript
+export interface FeatureRepository {
+  getNameInput(): Cypress.Chainable;
+  getEmailInput(): Cypress.Chainable;
+  getSubmitButton(): Cypress.Chainable;
+  getSuccessMessageSelector(): string;
+}
+```
+
+### Suite implementation file — `repositories/suite-<feature>-repository.ts`
+
+Must live inside the `repositories/` subfolder, must `implements FeatureRepository`, must be `@injectable`, must use `[data-qa="..."]` selectors.
+
+```typescript
+import { injectable } from 'inversify';
+import { FeatureRepository } from '../<feature>-repository';
+
+@injectable()
+export class SuiteFeatureRepository implements FeatureRepository {
+  getNameInput = (): Cypress.Chainable => cy.get('[data-qa="feature-name-input"]');
+  getEmailInput = (): Cypress.Chainable => cy.get('[data-qa="feature-email-input"]');
+  getSubmitButton = (): Cypress.Chainable => cy.get('[data-qa="feature-submit-button"]');
+  getSuccessMessageSelector = (): string => '[data-qa="feature-success-message"]';
+}
+```
+
+### ❌ Anti-pattern — DO NOT DO THIS
+
+A single concrete class with selectors inlined:
+```typescript
+// BAD: violates the interface+variant pattern
+@injectable()
+export class FeatureRepository {
+  getNameInput = (): Cypress.Chainable => cy.get('[data-qa="feature-name-input"]');
+  // …
+}
+```
+
+This is the most common failure mode — don't collapse the interface and impl into one class, even when only suite is supported. The interface still matters because:
+- DI uses `REPOSITORIES.FeatureRepository` as a `Symbol.for(...)` token — the interface is what's bound.
+- Future demoshop variants become a 30-line addition rather than a refactor of every consumer.
+
+### Selector priority
+
+1. `[data-qa="..."]` — always preferred
+2. `id` attribute — `[id="setting-key"]` if no `data-qa`
+3. `name` attribute — `[name="field_name"]` for form fields without `data-qa`
+4. Never use CSS classes, nth-child, or text matching
+
+### DI binding
+
+After creating the two files, register in `cypress/support/utils/inversify/inversify.config.ts`:
+
+```typescript
+container.bind(REPOSITORIES.FeatureRepository).to(SuiteFeatureRepository).inSingletonScope();
+```
+
+And add the token to `types.ts`:
+```typescript
+export const REPOSITORIES = {
+  // …existing
+  FeatureRepository: Symbol.for('FeatureRepository'),
+};
+```
+
+---
+
+## Scenarios (Reusable Flows)
+
+**Location**: `tests/cypress-tests/cypress/support/scenarios/{yves|backoffice|mp}/`
+
+```typescript
+import { inject, injectable } from 'inversify';
+import { autoWired } from '@utils';
+import { LoginPage } from '@pages/yves';
+
+@injectable()
+@autoWired
+export class CustomerLoginScenario {
+  @inject(LoginPage) private loginPage: LoginPage;
+
+  execute = (params: ExecuteParams): void => {
+    cy.session([params.email, params.password], () => {
+      this.loginPage.visit();
+      this.loginPage.login(params);
+    });
+  };
+}
+
+interface ExecuteParams {
+  email: string;
+  password: string;
+  withoutSession?: boolean;
+}
+```
+
+- Use `cy.session()` for login scenarios to avoid repeating auth across tests
+- Encapsulate multi-page flows (e.g. full checkout) in a single scenario
+- Scenarios inject pages via DI — never instantiate pages with `new`
+
+---
+
+## Fixtures
+
+### Static Fixtures (pre-seeded data, always present)
+
+**Location**: `tests/cypress-tests/cypress/fixtures/{repositoryId}/{layer}/{feature}/static-{test-name}.json`
+
+```json
+{
+  "defaultPassword": "change123",
+  "product": { "sku": "PRODUCT_SKU_001" }
+}
+```
+
+### Dynamic Fixtures (entities created via API before the test)
+
+**Location**: `tests/cypress-tests/cypress/fixtures/{repositoryId}/{layer}/{feature}/dynamic-{test-name}.json`
+
+```json
+{
+  "data": {
+    "type": "dynamic-fixtures",
+    "attributes": {
+      "synchronize": true,
+      "operations": [
+        {
+          "type": "helper",
+          "name": "haveConfirmedCustomer",
+          "key": "customer",
+          "arguments": [{ "password": "change123" }]
+        },
+        {
+          "type": "helper",
+          "name": "haveFullProduct",
+          "key": "product",
+          "arguments": [{}, { "idTaxSet": 1 }]
+        }
+      ]
+    }
+  }
+}
+```
+
+**Auto-discovery rule**: fixtures are loaded automatically based on the test file path. A test at `cypress/e2e/yves/checkout/basic-checkout.cy.ts` loads:
+- `fixtures/{repositoryId}/yves/checkout/static-basic-checkout.json`
+- `fixtures/{repositoryId}/yves/checkout/dynamic-basic-checkout.json`
+
+> ⚠️ **The fixture path mirrors the SPEC's path, exactly — `{spec-dir-relative-to-e2e}/static-{spec-filename}.json`. There is NO extra `{feature}` subfolder beyond what the spec's own directory already is.** `support/e2e.ts` computes it as `directoryPart = dirname(specPathRelativeToE2e)` and `filePart = specName.replace('.cy','')`. So a spec placed directly in a group dir, e.g. `cypress/e2e/demo/quicksight-analytics.cy.ts`, loads `fixtures/{repositoryId}/demo/static-quicksight-analytics.json` — **NOT** `…/demo/quicksight-analytics/static-quicksight-analytics.json`. Nesting the fixture one level too deep makes `Cypress.env('staticFixtures')` resolve to `undefined`, and the failure surfaces only at runtime as `TypeError: Cannot read properties of undefined (reading '<field>')` in `before`/`beforeEach` — typecheck, lint, and prettier all pass. **Always run the spec live (`cy:demo` / `cy:smoke` / the relevant `cy:ci:*`) before considering it done — never trust the static gates alone for fixture wiring.** The earlier "Directory Structure" diagrams show a `{feature}/` fixture subfolder ONLY because those example specs are themselves nested under a `{feature}/` directory; match the spec, not the diagram.
+
+**Smoke tests**: use static fixtures only — no dynamic fixtures, no CLI commands.
+
+---
+
+## TypeScript Interfaces for Fixtures
+
+**Location**: `tests/cypress-tests/cypress/support/types/{layer}/`
+
+```typescript
+// cypress/support/types/yves/index.ts
+export interface FeatureStaticFixtures {
+  defaultPassword: string;
+  product: { sku: string };
+}
+
+export interface FeatureDynamicFixtures {
+  customer: { email: string; id_customer: number };
+  product: { abstract_sku: string };
+}
+```
+
+Always define typed interfaces — never use `any` for fixture data.
+
+---
+
+## Inversify DI Registration
+
+After adding a new page, repository, or scenario, register it in:
+
+**File**: `tests/cypress-tests/cypress/support/utils/inversify/inversify.config.ts`
+
+```typescript
+import { SuiteFeatureRepository } from '../../pages/yves/feature/repositories/suite-feature-repository';
+import { FeaturePage } from '../../pages/yves/feature/feature-page';
+import { FeatureScenario } from '../../scenarios/yves/feature-scenario';
+
+container.bind(REPOSITORIES.FeatureRepository).to(SuiteFeatureRepository).inSingletonScope();
+container.bind(FeaturePage).to(FeaturePage).inSingletonScope();
+container.bind(FeatureScenario).to(FeatureScenario).inSingletonScope();
+```
+
+Add the repository token to `types.ts`:
+
+```typescript
+export const REPOSITORIES = {
+  // existing...
+  FeatureRepository: Symbol.for('FeatureRepository'),
+};
+```
+
+---
+
+## Wait Strategies
+
+**Good** — wait for observable state, not arbitrary time:
+```typescript
+cy.wait('@apiCall');                                          // wait for intercepted request
+cy.get('[data-qa="spinner"]').should('not.exist');           // wait for loader to disappear
+cy.get('[data-qa="data-table"]').should('contain', 'Item');  // wait for content to appear
+```
+
+**Bad** — never use arbitrary timeouts:
+```typescript
+cy.wait(5000); // arbitrary timeout — flaky, slow, and masks real issues
+```
+
+---
+
+## Anti-Patterns
+
+- `cy.wait(timeout)` without waiting for a specific condition
+- Assertions inside page objects — assertions belong only in test specs
+- Creating duplicate page objects — always search before creating
+- Tests that depend on execution order of other tests
+- Multiple unrelated scenarios in one test
+- Hardcoded test data in test specs
+- Inventing tags that don't exist in the Release App
+- Over-testing — only write tests that are explicitly required
+
+---
+
+## Updating Existing Tests
+
+When fixing or extending an existing test:
+
+1. **Read first** — read the test spec, its page objects, scenarios, and fixtures before changing anything
+2. **Identify root cause** — is the selector broken? did application behavior change? is it a timing issue?
+3. **Search for patterns** — check if a similar fix or helper already exists elsewhere
+4. **Plan minimal change** — what is the smallest change that resolves the issue?
+5. **Maintain style** — follow the existing naming, structure, and patterns in the file
+6. **Verify isolation** — confirm the change does not break other tests
+
+---
+
+## Debugging
+
+- Use `cy.log('message')` to track test progression
+- Add meaningful assertion messages: `cy.get(...).should('be.visible', 'Submit button should appear after form is filled')`
+- Use `cy.intercept()` to observe network requests when asserting on API-driven content
+- Use specific assertions — prefer `.should('contain', 'Success')` over `.should('exist')`
+
+---
+
+## Code Quality Checks
+
+After any change to test files, always run:
+
+```bash
+cd tests/cypress-tests
+npm run typecheck      # verify TypeScript types
+npm run lint           # check code style
+npm run prettier:write # format code
+```
+
+All three must pass before the task is complete.
+
+**Then run the spec live — the static gates do NOT prove the test works.** Fixture path mistakes, selector drift, login/CSRF issues, and timing all pass typecheck/lint/prettier and fail only at runtime. Run the actual spec against the running app with the correct `ENV_REPOSITORY_ID` (e.g. `b2b-mp` for this repo) and confirm it goes green:
+
+```bash
+ENV_REPOSITORY_ID=b2b-mp npx cypress run --spec "cypress/e2e/<group>/<feature>.cy.ts" --headless --browser chrome
+```
+
+If the spec is guarded to a single demoshop, also run it under a different `ENV_REPOSITORY_ID` to confirm it **skips cleanly** (pending, not erroring) rather than throwing during DI/`container.get` resolution.
+
+---
+
+## Custom Commands Reference
+
+```typescript
+cy.visitBackoffice('/url')           // navigate to backoffice URL
+cy.visitMerchantPortal('/url')       // navigate to merchant portal URL
+cy.resetYvesCookies()                // clear storefront session
+cy.resetBackofficeCookies()          // clear backoffice session
+cy.runCliCommands(['console oms:check-condition'])  // trigger backend CLI commands
+cy.runQueueWorker()                  // process message queues
+cy.loadDynamicFixturesByPayload(filePath)  // load dynamic fixtures manually
+cy.reloadUntilFound(url, selector, parentSelector, retries, wait)
+```
+
+---
+
+## Running Tests
+
+**Open interactive runner:**
+```bash
+cd tests/cypress-tests && npx cypress open
+```
+
+**Run all feature tests (non-smoke):**
+```bash
+cd tests/cypress-tests && npm run cy:run
+```
+
+**Run by layer:**
+```bash
+npm run cy:ci:yves        # storefront tests
+npm run cy:ci:backoffice  # backoffice tests
+npm run cy:ci:mp          # merchant portal tests
+npm run cy:ci:api         # API tests
+npm run cy:smoke          # smoke tests only
+npm run cy:demo           # isolated demo-only group (this repo) — see "The demo group"
+```
+
+**Run a single file:**
+```bash
+cd tests/cypress-tests && npx cypress run --spec "cypress/e2e/yves/checkout/basic-checkout.cy.ts" --headless --browser chrome
+```
+
+**Run by tag:**
+```bash
+cd tests/cypress-tests && npx cypress run --env grepTags="@checkout" --headless --browser chrome
+```
+
+---
+
+## Directory Structure for a New Feature
+
+```
+cypress/
+├── e2e/yves/feature-name/
+│   └── feature-name.cy.ts
+├── fixtures/suite/yves/feature-name/
+│   ├── static-feature-name.json
+│   └── dynamic-feature-name.json
+└── support/
+    ├── pages/yves/feature-name/
+    │   ├── feature-name-page.ts
+    │   ├── feature-name-repository.ts
+    │   └── repositories/
+    │       └── suite-feature-name-repository.ts
+    ├── scenarios/yves/
+    │   └── feature-name-scenario.ts
+    └── types/yves/
+        └── index.ts  (add interface exports here)
+```
+
+## Checklist for a New Feature Test
+
+0. **Discovery** (see top of file): grep feature sources, read PRD if present, confirm journey list with the user
+1. Create static fixture JSON (always required) — start with `suite` under `fixtures/suite/<layer>/<feature>/`
+2. Create dynamic fixture JSON (if entities need to be created) — same suite-first rule
+3. Define TypeScript interfaces for both fixtures
+4. Create the repository interface and a **`suite`** implementation first. Only add `b2b` / `b2b-mp` implementations if the user confirmed the feature ships in those demoshops during discovery — otherwise, flag it as a follow-up in your final summary
+5. Create the page class extending the correct base page
+6. Create a scenario class if the flow spans multiple pages
+7. Register all bindings in `inversify.config.ts` and `types.ts`
+8. Write the test file with `describe` tags and `before()` fixture loading
+9. Run the test to verify it passes

--- a/.claude/skills/upmerge-master-to-demo/README.md
+++ b/.claude/skills/upmerge-master-to-demo/README.md
@@ -1,0 +1,172 @@
+# Upmerge `master` → `master-demo` — Operator Guide
+
+This README explains the recurring **upmerge** workflow for the `b2b-demo-marketplace`
+repo in plain steps, with diagrams. The executable, command-by-command version lives in
+[`SKILL.md`](./SKILL.md) and runs via `/upmerge`. Read this first to understand *why*
+each step exists; use `SKILL.md` for the exact commands.
+
+## What an upmerge is
+
+`master-demo` is the demo branch. It is `master` **plus** demo-only additions (the AI
+Commerce features, demo data, branded Twig, demo-only config blocks, and the demo Cypress
+specs). Periodically we bring the latest `master` changes *into* `master-demo` so the demo
+branch doesn't drift. That direction — **`master` → `master-demo`, never the reverse** — is
+the upmerge.
+
+The hard part is everything `git merge` *cannot* see:
+
+- **Shadowed overrides** — a core Twig/class changes upstream while `src/Pyz` (or `src/Demo`)
+  shadows it; git sees no overlap, the override silently goes stale.
+- **Silently dropped demo-only config** — a reconciled master-side commit deletes a
+  demo-only block in `config/Shared/config_default.php` with **zero conflict markers**,
+  while the code reading it stays wired → runtime crash (the QuickSight incident).
+- **The external Cypress repo** — `spryker/cypress-tests` is a *separate* repo with its own
+  `master`/`master-demo`. The demo-shop merge never touches it; it must be upmerged
+  explicitly, and **by a specific commit hash, not by cypress master's tip** (see below).
+
+## The 12 steps
+
+| # | Step | Why it exists |
+|---|------|---------------|
+| 1 | **Find the JIRA ticket** | Drives the branch name + PR title (CC board 2237). |
+| 2 | **Sync `master` & `master-demo`** | Fetch + fast-forward refspecs so HEAD stays put; stop on dirty tree. |
+| 3 | **Create the feature branch** | `feature/<ticket>/upmerge-latest-master` off `master-demo`. |
+| 4 | **Merge `master`, resolve conflicts** | `composer.lock` → regenerate; `config_default.php` → never drop demo-only blocks. |
+| 5 | **Refresh `composer.lock`** | Final lock = master's lock **+** demo-only packages only. No bare `composer update`. |
+| 6a–6c | **Reconcile Pyz/Demo overrides** | Re-align overrides that shadow changed core files (esp. Twig). Silent divergence. |
+| 6d | **Audit `deploy.spryker-icpplus.yml`** | New feature may need a deploy entry/env var the merge never flagged. |
+| 6e | **Audit `config_default.php`** | Catch demo-only config blocks dropped with no conflict marker (QuickSight canary). |
+| **6f** | **Upmerge the `cypress-tests` repo** | **Merge cypress `master-demo` to the HASH demo-shop master pins — NOT cypress master's tip.** Re-pin the demo-shop. |
+| 7 | **Smoke-test Yves + Backoffice** | Login + customer overview + dashboard + `analytics-gui` (QuickSight canary). |
+| 7b | **Run `cy:demo`** | Mandatory automated coverage of demo-only features; predicts CI's `Run Tests (Demo)`. |
+| 8 | **Push + open PR** | Targets `master-demo`; PR body records every audit (6a–6f). |
+| 9 | **Move JIRA to IN CR** | Transition name "Start CR"; verify status actually changed. |
+| 10 | **Hand off + schedule poll** | Tell user; `ScheduleWakeup` for the pipeline check. |
+| 11 | **Poll pipeline + auto-fix** | phpcs/transfer/propel/lock are auto-fixable; logic/test failures go to the user. |
+| 12 | **Final report** | Green pipeline → JIRA comment + tell user. Never auto-merge. |
+
+## General flow
+
+```mermaid
+flowchart TD
+    A([/upmerge]) --> B[Step 1: Find JIRA ticket]
+    B --> C[Step 2: Sync master & master-demo]
+    C --> D{Working tree clean?}
+    D -- no --> Dx[Stop & ask user]
+    D -- yes --> E[Step 3: Branch off master-demo]
+    E --> F[Step 4: Merge master, resolve conflicts]
+    F --> G[Step 5: Reconstruct composer.lock = master + demo-only pkgs]
+
+    G --> H[Step 6a-6c: Reconcile Pyz/Demo overrides ]
+    H --> I[Step 6d: Audit deploy.spryker-icpplus.yml]
+    I --> J[Step 6e: Audit config_default.php demo-only blocks]
+    J --> K[[Step 6f: Upmerge cypress-tests repo — see cypress diagram]]
+
+    K --> L[Step 7: Smoke-test Yves + Backoffice + analytics-gui]
+    L --> M[Step 7b: npm run cy:demo]
+    M --> N{All green?}
+    N -- no --> Nx[Fix regression / ask user] --> H
+    N -- yes --> O[Step 8: Push + open PR to master-demo]
+    O --> P[Step 9: JIRA → IN CR + link PR]
+    P --> Q[Step 10: Hand off + ScheduleWakeup]
+    Q --> R[Step 11: Poll pipeline]
+    R --> S{Pipeline?}
+    S -- running --> R
+    S -- auto-fixable fail --> T[phpcbf / transfer / propel / lock] --> O
+    S -- logic/test fail --> Tx[Surface to user]
+    S -- green --> U[Step 12: JIRA comment + report]
+    U --> V([Done — user merges])
+```
+
+## Step 6f in detail — the cypress-tests upmerge
+
+`spryker/cypress-tests` is its own repo, checked out under `tests/cypress-tests/`. The
+demo-shop's `composer.json` pins it as `require-dev: "spryker/cypress-tests": "dev-master-demo"`,
+so the demo shop installs the cypress repo's `master-demo` branch.
+
+### Why merge by HASH, not by cypress master's tip
+
+The demo-shop's own `master` branch pins `spryker/cypress-tests` to a **specific commit
+reference** in its `composer.lock` (`source.reference`). Cypress `master` is almost always
+*far ahead* of that pinned commit — **64 commits ahead** in the 2026-06-27 case.
+
+```
+cypress repo:
+  master:       …──●──●──●──●──●──●  ← TIP (64 commits ahead — OFF LIMITS)
+                       │
+   demo-shop master    ●  TARGET_CYPRESS_HASH  (the pinned commit, e.g. 09e6cbcf)
+   pins this commit ──╯ │
+                        ↓ merge ONLY up to here
+  master-demo:  …──●────●──◇──◇        ← demo-only specs (◇) layered on the pinned base
+```
+
+If you ran `git merge master` in the cypress repo, `master-demo` would absorb all 64
+newer commits and run **ahead of the demo-shop version** — asserting selectors/fixtures/
+behavior the shop on `master` doesn't have yet → flaky, false failures, version skew.
+So cypress `master-demo` is advanced to **exactly the commit demo-shop master pins, and no
+further.** The pinned hash is the merge target; cypress master's tip is off-limits.
+
+After merging, you push the cypress `master-demo` branch and **re-pin the demo-shop's
+`composer.lock`** to the new cypress `master-demo` tip, so the demo shop installs the
+upmerged tests.
+
+### Cypress upmerge flow
+
+```mermaid
+flowchart TD
+    A([Step 6f start]) --> B["6f-1: Read demo-shop MASTER's composer.lock<br/>cypress source.reference → TARGET_CYPRESS_HASH"]
+    B --> C[6f-2: cd tests/cypress-tests; git fetch origin]
+    C --> D{Is TARGET_CYPRESS_HASH<br/>already in master-demo?}
+    D -- yes --> Dx[Record 'already at/ahead of pin —<br/>no merge needed'] --> RUN
+    D -- no --> E["6f-3: git checkout master-demo<br/>git merge TARGET_CYPRESS_HASH --no-ff<br/>(the HASH — never 'git merge master')"]
+    E --> F{Conflicts?}
+    F -- demo-only spec --> F1[Keep master-demo demo side] --> G
+    F -- shared/core spec --> F2[Take incoming up to the hash] --> G
+    F -- unclear --> Fx[Pause & ask user] --> G
+    F -- none --> G
+    G[6f-4: Verify TARGET is ancestor of master-demo]
+    G --> H{Any cypress-master commit<br/>NEWER than target leaked in?}
+    H -- yes --> Hx[LEAK: reset master-demo to pre-merge tip,<br/>redo 6f-3 with the HASH] --> E
+    H -- no --> RUN
+    RUN["6f-5: ENV_REPOSITORY_ID=b2b-mp npm run cy:demo"]
+    RUN --> I{All demo specs pass?}
+    I -- no --> Ix[Real regression — cross-ref Step 6e; fix / ask user] --> RUN
+    I -- yes --> J[git push origin master-demo<br/>capture new master-demo tip]
+    J --> K["Re-pin demo-shop:<br/>composer update spryker/cypress-tests --lock --no-install<br/>verify reference == new cypress master-demo tip"]
+    K --> L[git commit composer.lock<br/>record hashes in PR body]
+    L --> M([Step 6f done → continue Step 7])
+```
+
+### Key commands (full versions in `SKILL.md` Step 6f)
+
+```bash
+# 6f-1 — target hash = what demo-shop MASTER pins (run from demo-shop root)
+git show master:composer.lock | python3 -c "import json,sys; d=json.load(sys.stdin); p=[x for x in d['packages']+d['packages-dev'] if x['name']=='spryker/cypress-tests'][0]; print(p['source']['reference'])"
+
+# 6f-2/3 — merge the HASH into cypress master-demo (never 'git merge master')
+cd tests/cypress-tests && git fetch origin
+git merge-base --is-ancestor <TARGET_CYPRESS_HASH> master-demo && echo "already in master-demo" || echo "merge required"
+git checkout master-demo
+git merge <TARGET_CYPRESS_HASH> --no-ff -m "Upmerge cypress master (@<TARGET_CYPRESS_HASH>) into master-demo for <TICKET>"
+
+# 6f-4 — guard against leaking newer-than-target master commits
+git log --oneline <TARGET_CYPRESS_HASH>..origin/master | wc -l   # commits you must NOT have pulled in
+
+# 6f-5 — validate, push, re-pin demo-shop
+ENV_REPOSITORY_ID=b2b-mp ENV_IS_SSP_ENABLED=true npm run cy:demo
+git push origin master-demo
+# back in demo-shop root, on the upmerge branch:
+composer update spryker/cypress-tests --lock --no-install --ignore-platform-reqs
+git add composer.lock && git commit -m "chore(composer): re-pin spryker/cypress-tests to upmerged master-demo for <TICKET>"
+```
+
+## Golden rules
+
+- **`master` → `master-demo` only.** Never merge `master-demo` back into `master`.
+- **In the cypress repo: merge the HASH, never `git merge master`.** The demo cypress branch
+  must match what demo-shop master pins, not run ahead of it.
+- **A clean `git merge` is not "no work".** Steps 6a–6f catch the silent divergences git
+  can't flag.
+- **Never auto-merge the PR.** That's always the user's call.
+- **When intent is unclear — pause and ask.** A bad force-move or mis-merge costs far more
+  than one question.

--- a/.claude/skills/upmerge-master-to-demo/README.md
+++ b/.claude/skills/upmerge-master-to-demo/README.md
@@ -84,27 +84,36 @@ flowchart TD
 demo-shop's `composer.json` pins it as `require-dev: "spryker/cypress-tests": "dev-master-demo"`,
 so the demo shop installs the cypress repo's `master-demo` branch.
 
-### Why merge by HASH, not by cypress master's tip
+### Why merge by HASH, not by cypress master's tip — and which hash
 
-The demo-shop's own `master` branch pins `spryker/cypress-tests` to a **specific commit
-reference** in its `composer.lock` (`source.reference`). Cypress `master` is almost always
-*far ahead* of that pinned commit — **64 commits ahead** in the 2026-06-27 case.
+The demo-shop pins `spryker/cypress-tests` to a **specific commit reference** in its
+`composer.lock` (`source.reference`). Cypress `master` is almost always *far ahead* of that
+pinned commit — **64 commits ahead** in the 2026-06-27 case.
+
+**The PIN is the cypress version of the MERGED demo-shop — not master's tip.** The demo-shop
+`master-demo` only contains `master` up to the point it was last upmerged. So the cypress
+version it must match is the one pinned by the **master commit already merged into
+`master-demo`** = `git merge-base master master-demo`. (On the active upmerge branch — after
+`master` was merged in — that merged version is simply the branch's own `composer.lock`, read
+from `HEAD`.) Reading demo-shop **master's tip** instead would demand a cypress version for
+shop code `master-demo` doesn't have yet — the inverse skew.
 
 ```
-cypress repo:
-  master:       …──●──●──●──●──●──●  ← TIP (64 commits ahead — OFF LIMITS)
-                       │
-   demo-shop master    ●  TARGET_CYPRESS_HASH  (the pinned commit, e.g. 09e6cbcf)
-   pins this commit ──╯ │
-                        ↓ merge ONLY up to here
-  master-demo:  …──●────●──◇──◇        ← demo-only specs (◇) layered on the pinned base
+demo-shop repo:                          cypress repo:
+  master:  …──○──○──○  ← tip (newer pin)    master:  …──●──●──●──●──●──●  ← TIP (OFF LIMITS)
+              │                                          │
+  merge-base  ○  ← last master merged                    ●  TARGET_CYPRESS_HASH
+  into demo   │     into master-demo;                pin │     = cypress ref the merge-base
+              │     READ ITS cypress pin   ───────────╯  │       commit's lock points to
+  master-demo ○──◆──◆  (◆ = demo-only)      master-demo: …──●──◇──◇  (◇ = demo-only specs)
+                                                          ↑ merge ONLY up to TARGET, no further
 ```
 
-If you ran `git merge master` in the cypress repo, `master-demo` would absorb all 64
-newer commits and run **ahead of the demo-shop version** — asserting selectors/fixtures/
-behavior the shop on `master` doesn't have yet → flaky, false failures, version skew.
-So cypress `master-demo` is advanced to **exactly the commit demo-shop master pins, and no
-further.** The pinned hash is the merge target; cypress master's tip is off-limits.
+If you ran `git merge master` in the cypress repo, `master-demo` would absorb all 64 newer
+commits and run **ahead of the demo-shop version** — asserting selectors/fixtures/behavior the
+shop doesn't have yet → flaky, false failures, version skew. So cypress `master-demo` is
+advanced to **exactly the commit the merged demo-shop version pins, and no further.** The
+pinned hash is the merge target; cypress master's tip is off-limits.
 
 After merging, you push the cypress `master-demo` branch and **re-pin the demo-shop's
 `composer.lock`** to the new cypress `master-demo` tip, so the demo shop installs the
@@ -114,34 +123,38 @@ upmerged tests.
 
 ```mermaid
 flowchart TD
-    A([Step 6f start]) --> B["6f-1: Read demo-shop MASTER's composer.lock<br/>cypress source.reference → TARGET_CYPRESS_HASH"]
-    B --> C[6f-2: cd tests/cypress-tests; git fetch origin]
+    A([Step 6f start]) --> B["6f-1: TARGET_CYPRESS_HASH = cypress source.reference<br/>from the MERGED demo-shop lock<br/>(branch HEAD mid-upmerge, else merge-base master..master-demo)"]
+    B --> C["6f-2: cd tests/cypress-tests, git fetch origin"]
     C --> D{Is TARGET_CYPRESS_HASH<br/>already in master-demo?}
-    D -- yes --> Dx[Record 'already at/ahead of pin —<br/>no merge needed'] --> RUN
+    D -- yes --> Dx["Record 'already at/ahead of pin — no merge needed'"] --> RUN
     D -- no --> E["6f-3: git checkout master-demo<br/>git merge TARGET_CYPRESS_HASH --no-ff<br/>(the HASH — never 'git merge master')"]
     E --> F{Conflicts?}
-    F -- demo-only spec --> F1[Keep master-demo demo side] --> G
-    F -- shared/core spec --> F2[Take incoming up to the hash] --> G
-    F -- unclear --> Fx[Pause & ask user] --> G
+    F -- demo-only spec --> F1["Keep master-demo demo side"] --> G
+    F -- shared/core spec --> F2["Take incoming up to the hash"] --> G
+    F -- unclear --> Fx["Pause and ask user"] --> G
     F -- none --> G
-    G[6f-4: Verify TARGET is ancestor of master-demo]
+    G["6f-4: Verify TARGET is ancestor of master-demo"]
     G --> H{Any cypress-master commit<br/>NEWER than target leaked in?}
-    H -- yes --> Hx[LEAK: reset master-demo to pre-merge tip,<br/>redo 6f-3 with the HASH] --> E
+    H -- yes --> Hx["LEAK: reset master-demo to pre-merge tip,<br/>redo 6f-3 with the HASH"] --> E
     H -- no --> RUN
     RUN["6f-5: ENV_REPOSITORY_ID=b2b-mp npm run cy:demo"]
     RUN --> I{All demo specs pass?}
-    I -- no --> Ix[Real regression — cross-ref Step 6e; fix / ask user] --> RUN
+    I -- no --> Ix["Real regression — cross-ref Step 6e; fix / ask user"] --> RUN
     I -- yes --> J[git push origin master-demo<br/>capture new master-demo tip]
     J --> K["Re-pin demo-shop:<br/>composer update spryker/cypress-tests --lock --no-install<br/>verify reference == new cypress master-demo tip"]
     K --> L[git commit composer.lock<br/>record hashes in PR body]
-    L --> M([Step 6f done → continue Step 7])
+    L --> M(["Step 6f done - continue Step 7"])
 ```
 
 ### Key commands (full versions in `SKILL.md` Step 6f)
 
 ```bash
-# 6f-1 — target hash = what demo-shop MASTER pins (run from demo-shop root)
-git show master:composer.lock | python3 -c "import json,sys; d=json.load(sys.stdin); p=[x for x in d['packages']+d['packages-dev'] if x['name']=='spryker/cypress-tests'][0]; print(p['source']['reference'])"
+# 6f-1 — target hash = cypress ref the MERGED demo-shop version pins.
+# On the upmerge branch (master already merged in), read the branch lock:
+git show HEAD:composer.lock | python3 -c "import json,sys; d=json.load(sys.stdin); p=[x for x in d['packages']+d['packages-dev'] if x['name']=='spryker/cypress-tests'][0]; print(p['source']['reference'])"
+# Standalone (validating master-demo directly), read the merge-base lock instead:
+MB=$(git merge-base master master-demo)
+git show "${MB}:composer.lock" | python3 -c "import json,sys; d=json.load(sys.stdin); p=[x for x in d['packages']+d['packages-dev'] if x['name']=='spryker/cypress-tests'][0]; print(p['source']['reference'])"
 
 # 6f-2/3 — merge the HASH into cypress master-demo (never 'git merge master')
 cd tests/cypress-tests && git fetch origin
@@ -159,6 +172,45 @@ git push origin master-demo
 composer update spryker/cypress-tests --lock --no-install --ignore-platform-reqs
 git add composer.lock && git commit -m "chore(composer): re-pin spryker/cypress-tests to upmerged master-demo for <TICKET>"
 ```
+
+## Quality gate: `check-cypress-not-ahead.sh`
+
+A standalone script in this folder enforces the rule above deterministically — it fails
+if cypress `master-demo` is **ahead of** (or **behind**) the cypress version pinned by the
+**merged demo-shop version**. By default it derives that PIN from the **merge-base of
+demo-shop `master` and `master-demo`** (the latest master version already in `master-demo`),
+so it's correct even run standalone. Use it in Step 6f-4, as a pre-push hook, or as a CI gate.
+
+```bash
+# From the demo-shop repo root — auto-detects tests/cypress-tests:
+.claude/skills/upmerge-master-to-demo/check-cypress-not-ahead.sh
+```
+
+**What it asserts** (TARGET = `spryker/cypress-tests` `source.reference` read from the PIN ref — by default the merge-base `master`..`master-demo`):
+
+| Check | Passes when | Fails when |
+|---|---|---|
+| 1 — not behind | TARGET is an ancestor of cypress `master-demo` | `master-demo` doesn't contain the pin (merge missing/incomplete) |
+| 2 — not ahead | no commit reachable from `master-demo` is newer than TARGET on cypress `master` | a cypress-master commit newer than the pin leaked into `master-demo` |
+
+**Exit codes:** `0` pass · `1` gate failed (lists the offending commits for the ahead case) · `2` setup error.
+
+**Env overrides** (all optional):
+- `DEMOSHOP_MASTER` (default `master`) and `DEMOSHOP_DEMO` (default `master-demo`) — the two branches the PIN merge-base is computed from.
+- `DEMOSHOP_REF` — read the PIN from this explicit ref instead of the merge-base (e.g. `DEMOSHOP_REF=HEAD` on the upmerge branch to validate the exact lock you're about to ship).
+- `TARGET_HASH` — supply the PIN hash directly, skipping composer.lock entirely.
+- `CYPRESS_DEMO` (default `master-demo`), `CYPRESS_MASTER` (default `origin/master`), `CYPRESS_DIR`, `DEMOSHOP_DIR`, `NO_FETCH=1` (skip `git fetch`).
+
+**As a CI step** (e.g. GitHub Actions) — run it after checking out both the demo-shop and the
+cypress branch so the refs are present:
+
+```yaml
+  - name: Cypress demo branch not ahead of demo-shop pin
+    run: .claude/skills/upmerge-master-to-demo/check-cypress-not-ahead.sh
+```
+
+The gate maps 1:1 to Step 6f-4 — a green local run predicts the CI gate, and a red CI gate
+points straight back to Step 6f (re-merge the **hash**, not cypress `master`).
 
 ## Golden rules
 

--- a/.claude/skills/upmerge-master-to-demo/SKILL.md
+++ b/.claude/skills/upmerge-master-to-demo/SKILL.md
@@ -29,7 +29,7 @@ If the user only asks for *part* of the flow (e.g. "just open the PR for me"), d
 4. Merge `master` into it, resolve conflicts
 5. Refresh `composer.lock` and run `composer install` locally
 6. Reconcile Pyz overrides with the incoming changes (esp. Twig templates), audit `deploy.spryker-icpplus.yml` against the sibling deploy files, and audit `config/Shared/config_default.php` for demo-only config blocks the merge silently dropped
-7. Smoke-test Yves and Backoffice login via the `login-chrome` skill
+7. Smoke-test Yves and Backoffice login via the `login-chrome` skill, then ALWAYS run the demo Cypress group (`cy:demo`)
 8. Push and open a PR targeting `master-demo`
 9. Move the JIRA ticket to **IN CR**
 10. Ask the user to review, then poll the GitHub Actions pipeline starting at +2h
@@ -430,6 +430,22 @@ Use `Skill(login-chrome)` (or `/login-chrome`) to drive the browser. If a login 
 
 If your environment doesn't have the local Spryker stack running, ask the user whether to skip the smoke test (don't silently skip — they may want to start docker first).
 
+## Step 7b — ALWAYS run the demo Cypress group (`cy:demo`)
+
+The `cypress/e2e/demo/` group is the **automated, isolated coverage for demo-only features that live only on `master-demo`** (QuickSight Analytics and the other AI Commerce features). These are exactly the surfaces an upmerge most often breaks via dropped demo-only config/wiring (Step 6e), so this run is **mandatory on every upmerge — never skip it**, even on a clean merge. It supersedes the manual analytics-gui canary (it asserts the same QuickSight 200/graceful-state, plus more, deterministically).
+
+Run it against the local stack with the demo repository id:
+
+```bash
+cd tests/cypress-tests
+ENV_REPOSITORY_ID=b2b-mp ENV_IS_SSP_ENABLED=true npm run cy:demo
+```
+
+- **All specs must pass.** A failure here is a real regression — most likely a demo-only block dropped during the merge (cross-reference Step 6e Checks 1–4). Do **not** push until it's green or the user explicitly accepts the failure.
+- If the local Spryker stack isn't running, ask the user whether to start docker or skip — same rule as Step 7, don't silently skip.
+- If `cy:demo` doesn't exist yet (older branch), that itself is a finding: the demo group / CI step may have been lost in the merge — restore it (see the `cypress-e2e-test` skill's "demo group" section) before pushing.
+- The same `cy:demo` runs in CI as its own `Run Tests (Demo)` step (`if: always()`), so a green local run predicts the CI step; a red CI demo step in Step 11 maps straight back here.
+
 ## Step 8 — Push and open the PR
 
 ```bash
@@ -454,7 +470,8 @@ JIRA: <TICKET-URL>
 - [x] config/Shared/config_default.php audited for dropped demo-only config blocks (Step 6e)
 - [x] Local smoke test: Yves storefront login + customer overview
 - [x] Local smoke test: Backoffice login + dashboard + analytics-gui (QuickSight canary)
-- [ ] CI pipeline green
+- [x] Demo Cypress group green locally (`npm run cy:demo`, `ENV_REPOSITORY_ID=b2b-mp`)
+- [ ] CI pipeline green (incl. the `Run Tests (Demo)` step)
 
 ## Pyz override reconciliation
 <!-- List Pyz files kept / adapted / aligned from Step 6. Note "none" if the merge touched no Pyz files and no core-template overrides were affected. -->

--- a/.claude/skills/upmerge-master-to-demo/SKILL.md
+++ b/.claude/skills/upmerge-master-to-demo/SKILL.md
@@ -28,7 +28,7 @@ If the user only asks for *part* of the flow (e.g. "just open the PR for me"), d
 3. Create a feature branch off `master-demo`
 4. Merge `master` into it, resolve conflicts
 5. Refresh `composer.lock` and run `composer install` locally
-6. Reconcile Pyz overrides with the incoming changes (esp. Twig templates), audit `deploy.spryker-icpplus.yml` against the sibling deploy files, and audit `config/Shared/config_default.php` for demo-only config blocks the merge silently dropped
+6. Reconcile Pyz overrides with the incoming changes (esp. Twig templates), audit `deploy.spryker-icpplus.yml` against the sibling deploy files, audit `config/Shared/config_default.php` for demo-only config blocks the merge silently dropped, **and upmerge the external `spryker/cypress-tests` repo's `master-demo` branch up to the cypress commit the demo-shop `master` pins (Step 6f)**
 7. Smoke-test Yves and Backoffice login via the `login-chrome` skill, then ALWAYS run the demo Cypress group (`cy:demo`)
 8. Push and open a PR targeting `master-demo`
 9. Move the JIRA ticket to **IN CR**
@@ -416,6 +416,98 @@ If wiring remains for a removed config block, you have an inconsistent state (li
 
 Record the outcome (keys restored / confirmed intentionally removed / none) in the PR body alongside the Pyz and deploy audits.
 
+### Step 6f — Upmerge the external `spryker/cypress-tests` repo (CRITICAL — merge by HASH, not cypress master tip)
+
+The demo-shop pins `spryker/cypress-tests` to its **own `master-demo` branch** (`require-dev: "spryker/cypress-tests": "dev-master-demo"`), checked out under `tests/cypress-tests/` (composer installs it from git source). This is a **separate repository with its own `master` and `master-demo` branches** — the demo-shop upmerge does **not** touch it. You must upmerge it explicitly, and the version of the cypress `master-demo` branch **must match the cypress version the demo-shop `master` is pinned to**.
+
+> **Why merge by HASH, never from cypress `master`'s tip — this is the whole point of the step.**
+> The demo-shop's own `master` branch pins `spryker/cypress-tests` to a **specific commit reference** in its `composer.lock` (the `source.reference` hash). Cypress `master` is almost always *dozens of commits ahead* of that pinned hash (e.g. **64 commits ahead** in the 2026-06-27 case). If you merge cypress `master`'s **tip** into cypress `master-demo`, the demo cypress branch ends up running **ahead of the demo-shop version** — it would assert behavior/selectors/fixtures the shop on `master` doesn't have yet → flaky/false failures and a version-skewed demo branch. So cypress `master-demo` must be advanced to **exactly the cypress commit the demo-shop `master` pins, and no further.** That pinned hash is your merge target; cypress `master`'s tip is off-limits.
+
+#### Step 6f-1 — Determine the target cypress commit (the hash demo-shop `master` pins)
+
+Read the cypress reference from the demo-shop's `master` lock (NOT from `master-demo`, NOT from cypress `master`):
+
+```bash
+# Run from the demo-shop repo root.
+git show master:composer.lock | python3 -c "import json,sys; d=json.load(sys.stdin); p=[x for x in d['packages']+d['packages-dev'] if x['name']=='spryker/cypress-tests'][0]; print('demo-shop master pins cypress at:', p['source']['reference'])"
+```
+
+Call that hash `TARGET_CYPRESS_HASH`. This — not cypress `origin/master` — is the upper bound for the merge.
+
+#### Step 6f-2 — In the cypress repo, sync and validate the relationship
+
+```bash
+cd tests/cypress-tests
+git fetch origin
+git rev-parse master-demo                 # current demo branch tip
+git log --oneline -1 <TARGET_CYPRESS_HASH>  # confirm the pinned commit exists & see what it is
+
+# Sanity guards — surface to the user if either is surprising:
+# (a) Is the target already in master-demo? If YES, there is nothing to merge — master-demo is already at/ahead of the pin.
+git merge-base --is-ancestor <TARGET_CYPRESS_HASH> master-demo && echo "Target already in master-demo — no merge needed" || echo "Target NOT yet in master-demo — merge required"
+# (b) How far is cypress master AHEAD of the target? Those are the commits you MUST NOT pull in.
+echo "Commits on cypress master that are AHEAD of the target hash (DO NOT MERGE THESE):"
+git log --oneline <TARGET_CYPRESS_HASH>..origin/master | wc -l
+```
+
+If guard (a) says "already in master-demo", record "cypress master-demo already at/ahead of demo-shop master's pin — no upmerge needed" in the PR body and skip to Step 6f-5 (still run `cy:demo` in Step 7b).
+
+#### Step 6f-3 — Merge the target HASH into cypress `master-demo` (never `master`)
+
+```bash
+cd tests/cypress-tests
+git checkout master-demo
+git merge <TARGET_CYPRESS_HASH> --no-ff -m "Upmerge cypress master (@<TARGET_CYPRESS_HASH>) into master-demo for <TICKET>"
+```
+
+- **Use the hash, not `git merge master`.** `git merge master` would pull cypress master's tip and everything ahead of the pin — exactly the version skew this step exists to prevent.
+- **Conflict policy**: cypress `master-demo` carries the **demo-only specs** (the `cypress/e2e/demo/` group and any demo fixtures/config). When a conflict touches a demo-only file, keep the `master-demo` (demo) side. For shared/core specs and helpers, take the incoming (master) side up to the pinned hash. When intent is unclear, **pause and ask the user**.
+
+#### Step 6f-4 — Double-check you did NOT merge ahead of the target
+
+After the merge, verify cypress `master-demo` contains the target but **nothing from cypress master that is newer than the target**:
+
+```bash
+cd tests/cypress-tests
+# Target must now be an ancestor of master-demo:
+git merge-base --is-ancestor <TARGET_CYPRESS_HASH> master-demo && echo "OK: target is in master-demo" || echo "PROBLEM: target missing"
+# master-demo must NOT contain any commit that is ahead of the target on cypress master:
+echo "Cypress-master commits AHEAD of the target that leaked into master-demo (MUST be empty):"
+git log --oneline <TARGET_CYPRESS_HASH>..origin/master ^$(git rev-parse master-demo) 2>/dev/null | head
+# Equivalent, clearer phrasing — newer-than-target master commits now reachable from master-demo:
+git log --oneline master-demo --not <TARGET_CYPRESS_HASH> | grep -Ff <(git log --format=%h <TARGET_CYPRESS_HASH>..origin/master) - 2>/dev/null && echo "LEAK DETECTED — reset and redo with the hash" || echo "OK: no newer-than-target master commits in master-demo"
+```
+
+If a leak is detected, reset cypress `master-demo` to its pre-merge tip and redo Step 6f-3 with the **hash** (not `master`). Surface to the user before force-moving the branch.
+
+#### Step 6f-5 — Run the demo cypress group, push, and re-pin the demo-shop
+
+1. Run the demo group against the local stack (this is also Step 7b — running it here validates the just-merged cypress branch):
+   ```bash
+   cd tests/cypress-tests
+   ENV_REPOSITORY_ID=b2b-mp ENV_IS_SSP_ENABLED=true npm run cy:demo
+   ```
+   All specs must pass before pushing.
+
+2. Push cypress `master-demo` (this is a push to the **external `spryker/cypress-tests` repo**, separate from the demo-shop PR):
+   ```bash
+   cd tests/cypress-tests
+   git push origin master-demo
+   ```
+   Capture the new `master-demo` tip hash — that becomes the demo-shop's new pin.
+
+3. Re-pin the demo-shop's `composer.lock` to the new cypress `master-demo` reference so the demo shop installs the upmerged tests:
+   ```bash
+   # From the demo-shop repo root, on the upmerge feature branch.
+   composer update spryker/cypress-tests --lock --no-install --ignore-platform-reqs
+   # Verify the reference now matches the cypress master-demo tip you just pushed:
+   python3 -c "import json; d=json.load(open('composer.lock')); p=[x for x in d['packages']+d['packages-dev'] if x['name']=='spryker/cypress-tests'][0]; print('demo-shop now pins cypress at:', p['version'], p['source']['reference'])"
+   git add composer.lock
+   git commit -m "chore(composer): re-pin spryker/cypress-tests to upmerged master-demo for <TICKET>"
+   ```
+
+Record in the PR body: the `TARGET_CYPRESS_HASH` you merged to, the new cypress `master-demo` tip you pushed, and confirmation that no newer-than-target cypress-master commits leaked in.
+
 ## Step 7 — Smoke-test Yves and Backoffice login
 
 Invoke the `login-chrome` skill to verify the local stack still works after the merge. The smoke test scope is:
@@ -468,6 +560,7 @@ JIRA: <TICKET-URL>
 - [x] Pyz override reconciliation (incl. Twig templates shadowing changed core)
 - [x] deploy.spryker-icpplus.yml audited vs sibling deploy files
 - [x] config/Shared/config_default.php audited for dropped demo-only config blocks (Step 6e)
+- [x] spryker/cypress-tests `master-demo` upmerged to demo-shop master's pinned cypress hash, NOT cypress master tip (Step 6f); demo-shop re-pinned
 - [x] Local smoke test: Yves storefront login + customer overview
 - [x] Local smoke test: Backoffice login + dashboard + analytics-gui (QuickSight canary)
 - [x] Demo Cypress group green locally (`npm run cy:demo`, `ENV_REPOSITORY_ID=b2b-mp`)
@@ -481,6 +574,9 @@ JIRA: <TICKET-URL>
 
 ## config_default.php demo-only block audit (Step 6e)
 <!-- Result of Checks (1)-(4): list any demo-only config keys/imports restored (e.g. AmazonQuicksight), or "none dropped". Confirm analytics-gui smoke check returned 200. -->
+
+## cypress-tests repo upmerge (Step 6f)
+<!-- TARGET_CYPRESS_HASH (the cypress commit demo-shop master pins) merged into cypress master-demo; new cypress master-demo tip pushed; demo-shop composer.lock re-pinned to it; confirmed NO newer-than-target cypress-master commits leaked in. Note "already at/ahead of pin — no merge needed" if applicable. -->
 EOF
 )"
 ```
@@ -600,6 +696,7 @@ Don't merge the PR — that's the user's call.
 - **Don't treat a clean merge as "no Pyz work."** `git merge` only flags overlapping line edits. A core Twig template changing while Demo's `src/Pyz` override shadows it produces ZERO conflict markers but a stale override — Step 6 exists to catch exactly this. Always run Step 6's checks even when the merge applied cleanly.
 - **Don't blindly accept master's Pyz over Demo's.** Demo intentionally diverges in some Pyz files (branded/marketplace markup). When a divergence's intent is unclear, ask the user rather than overwriting.
 - **Don't trust a clean `config/Shared/config_default.php` merge.** Demo-only config blocks (QuickSight, demo S3 bucket shapes, demo toggles) can be deleted by a reconciled master-side commit with ZERO conflict markers, and the code reading them stays wired → runtime crash. Always run Step 6e's key/import diff and the analytics-gui canary, even when the merge applied cleanly. When a demo-only key vanished, default to restoring it and ask the user if intent is unclear.
+- **Never `git merge master` in the cypress-tests repo (Step 6f).** Cypress `master` runs dozens of commits ahead of the hash the demo-shop `master` pins. Merge the **pinned hash** into cypress `master-demo`, then verify no newer-than-target cypress-master commits leaked in. Merging cypress master's tip puts the demo cypress branch ahead of the shop version → flaky/false test failures. The demo cypress branch version must always match what demo-shop master pins.
 - **Pipeline polling is best-effort.** If the wake-up doesn't fire for any reason, the user can re-invoke the skill with `/upmerge poll PR <N> ticket <KEY>` and it'll resume from the polling step.
 
 ## Polling-only invocation

--- a/.claude/skills/upmerge-master-to-demo/SKILL.md
+++ b/.claude/skills/upmerge-master-to-demo/SKILL.md
@@ -421,18 +421,27 @@ Record the outcome (keys restored / confirmed intentionally removed / none) in t
 The demo-shop pins `spryker/cypress-tests` to its **own `master-demo` branch** (`require-dev: "spryker/cypress-tests": "dev-master-demo"`), checked out under `tests/cypress-tests/` (composer installs it from git source). This is a **separate repository with its own `master` and `master-demo` branches** — the demo-shop upmerge does **not** touch it. You must upmerge it explicitly, and the version of the cypress `master-demo` branch **must match the cypress version the demo-shop `master` is pinned to**.
 
 > **Why merge by HASH, never from cypress `master`'s tip — this is the whole point of the step.**
-> The demo-shop's own `master` branch pins `spryker/cypress-tests` to a **specific commit reference** in its `composer.lock` (the `source.reference` hash). Cypress `master` is almost always *dozens of commits ahead* of that pinned hash (e.g. **64 commits ahead** in the 2026-06-27 case). If you merge cypress `master`'s **tip** into cypress `master-demo`, the demo cypress branch ends up running **ahead of the demo-shop version** — it would assert behavior/selectors/fixtures the shop on `master` doesn't have yet → flaky/false failures and a version-skewed demo branch. So cypress `master-demo` must be advanced to **exactly the cypress commit the demo-shop `master` pins, and no further.** That pinned hash is your merge target; cypress `master`'s tip is off-limits.
+> The demo-shop pins `spryker/cypress-tests` to a **specific commit reference** in its `composer.lock` (the `source.reference` hash). Cypress `master` is almost always *dozens of commits ahead* of that pinned hash (e.g. **64 commits ahead** in the 2026-06-27 case). If you merge cypress `master`'s **tip** into cypress `master-demo`, the demo cypress branch ends up running **ahead of the demo-shop version** — it would assert behavior/selectors/fixtures the shop doesn't have yet → flaky/false failures and a version-skewed demo branch. So cypress `master-demo` must be advanced to **exactly the cypress commit the merged demo-shop version pins, and no further.** That pinned hash is your merge target; cypress `master`'s tip is off-limits.
+>
+> **Which demo-shop version's pin? The MERGED one — not master's tip.** The demo-shop `master-demo` only contains `master` up to the point it was last upmerged, not `master`'s current tip. So the correct cypress version is the one pinned by the **master commit already merged into `master-demo`** = `git merge-base master master-demo`. On the active upmerge branch (after Step 4 merged `master` in), that merged version is simply the branch's own `composer.lock` (read it from `HEAD`). The standalone quality gate (Step 6f-4) defaults to the merge-base so it's correct even when run against `master-demo` directly.
 
-#### Step 6f-1 — Determine the target cypress commit (the hash demo-shop `master` pins)
+#### Step 6f-1 — Determine the target cypress commit (the cypress version the merged demo-shop pins)
 
-Read the cypress reference from the demo-shop's `master` lock (NOT from `master-demo`, NOT from cypress `master`):
+On the active upmerge branch, Step 4 already merged `master` into it — so the branch's own `composer.lock` carries the cypress reference of the merged master version. Read it from the branch (`HEAD`):
 
 ```bash
-# Run from the demo-shop repo root.
-git show master:composer.lock | python3 -c "import json,sys; d=json.load(sys.stdin); p=[x for x in d['packages']+d['packages-dev'] if x['name']=='spryker/cypress-tests'][0]; print('demo-shop master pins cypress at:', p['source']['reference'])"
+# Run from the demo-shop repo root, on the upmerge feature branch.
+git show HEAD:composer.lock | python3 -c "import json,sys; d=json.load(sys.stdin); p=[x for x in d['packages']+d['packages-dev'] if x['name']=='spryker/cypress-tests'][0]; print('merged demo-shop pins cypress at:', p['source']['reference'])"
 ```
 
-Call that hash `TARGET_CYPRESS_HASH`. This — not cypress `origin/master` — is the upper bound for the merge.
+If you are NOT mid-merge (e.g. validating `master-demo` standalone), read the **merge-base** pin instead — the latest master version actually in `master-demo`:
+
+```bash
+MB=$(git merge-base master master-demo)
+git show "${MB}:composer.lock" | python3 -c "import json,sys; d=json.load(sys.stdin); p=[x for x in d['packages']+d['packages-dev'] if x['name']=='spryker/cypress-tests'][0]; print('merged master version pins cypress at:', p['source']['reference'])"
+```
+
+Call that hash `TARGET_CYPRESS_HASH`. This — not cypress `origin/master`, and not necessarily demo-shop `master`'s *tip* — is the upper bound for the merge.
 
 #### Step 6f-2 — In the cypress repo, sync and validate the relationship
 
@@ -463,22 +472,26 @@ git merge <TARGET_CYPRESS_HASH> --no-ff -m "Upmerge cypress master (@<TARGET_CYP
 - **Use the hash, not `git merge master`.** `git merge master` would pull cypress master's tip and everything ahead of the pin — exactly the version skew this step exists to prevent.
 - **Conflict policy**: cypress `master-demo` carries the **demo-only specs** (the `cypress/e2e/demo/` group and any demo fixtures/config). When a conflict touches a demo-only file, keep the `master-demo` (demo) side. For shared/core specs and helpers, take the incoming (master) side up to the pinned hash. When intent is unclear, **pause and ask the user**.
 
-#### Step 6f-4 — Double-check you did NOT merge ahead of the target
+#### Step 6f-4 — Run the quality gate (double-check you did NOT merge ahead of the target)
 
-After the merge, verify cypress `master-demo` contains the target but **nothing from cypress master that is newer than the target**:
+Run the bundled quality-gate script — by default it derives the pin from the **merge-base of demo-shop `master` and `master-demo`** (the merged master version already in `master-demo`), then asserts (1) the pin is contained in cypress `master-demo` and (2) **no cypress-master commit newer than the pin leaked into `master-demo`**. On the active upmerge branch you can point it at the branch lock with `DEMOSHOP_REF=HEAD` to validate the exact lock you're about to ship:
 
 ```bash
-cd tests/cypress-tests
-# Target must now be an ancestor of master-demo:
-git merge-base --is-ancestor <TARGET_CYPRESS_HASH> master-demo && echo "OK: target is in master-demo" || echo "PROBLEM: target missing"
-# master-demo must NOT contain any commit that is ahead of the target on cypress master:
-echo "Cypress-master commits AHEAD of the target that leaked into master-demo (MUST be empty):"
-git log --oneline <TARGET_CYPRESS_HASH>..origin/master ^$(git rev-parse master-demo) 2>/dev/null | head
-# Equivalent, clearer phrasing — newer-than-target master commits now reachable from master-demo:
-git log --oneline master-demo --not <TARGET_CYPRESS_HASH> | grep -Ff <(git log --format=%h <TARGET_CYPRESS_HASH>..origin/master) - 2>/dev/null && echo "LEAK DETECTED — reset and redo with the hash" || echo "OK: no newer-than-target master commits in master-demo"
+# From the demo-shop repo root (auto-detects tests/cypress-tests):
+.claude/skills/upmerge-master-to-demo/check-cypress-not-ahead.sh
 ```
 
-If a leak is detected, reset cypress `master-demo` to its pre-merge tip and redo Step 6f-3 with the **hash** (not `master`). Surface to the user before force-moving the branch.
+Exit `0` = gate passes. Exit `1` = gate fails: it prints which check failed and, for the "ahead" case, the exact offending commits. Exit `2` = setup error (wrong dir, missing ref).
+
+This is the same gate that runs in CI (see README). If it fails with **check 2 (ahead)**, reset cypress `master-demo` to its pre-merge tip and redo Step 6f-3 with the **hash** (not `master`). If it fails with **check 1 (behind)**, the merge didn't happen / didn't reach the pin — redo Step 6f-3. Surface to the user before force-moving the branch.
+
+> The script just wraps these two `git` facts, if you want to run them by hand:
+> ```bash
+> cd tests/cypress-tests
+> git merge-base --is-ancestor <TARGET_CYPRESS_HASH> master-demo   # check 1: pin is in master-demo
+> comm -12 <(git rev-list master-demo --not <TARGET_CYPRESS_HASH> | sort) \
+>          <(git rev-list <TARGET_CYPRESS_HASH>..origin/master | sort)   # check 2: must print nothing
+> ```
 
 #### Step 6f-5 — Run the demo cypress group, push, and re-pin the demo-shop
 

--- a/.claude/skills/upmerge-master-to-demo/check-cypress-not-ahead.sh
+++ b/.claude/skills/upmerge-master-to-demo/check-cypress-not-ahead.sh
@@ -1,0 +1,228 @@
+#!/usr/bin/env bash
+#
+# Quality gate: assert the cypress-tests `master-demo` branch matches the cypress
+# version pinned by the MASTER VERSION ALREADY MERGED INTO the demo-shop `master-demo`
+# — and is not ahead of it.
+#
+# WHY THE PIN COMES FROM THE MERGE-BASE, not from master's tip:
+#   The demo-shop pins `spryker/cypress-tests` to a commit in composer.lock
+#   (packages[spryker/cypress-tests].source.reference). But demo-shop `master-demo`
+#   usually does NOT contain master's latest — it contains master only up to the point
+#   it was last upmerged. The cypress version master-demo should match is the one pinned
+#   by the LATEST master commit master-demo actually has = `git merge-base master master-demo`.
+#   Using master's TIP pin instead would demand a cypress version for shop code that
+#   master-demo doesn't have yet (the inverse skew). Using the merge-base pin is correct.
+#
+#   Then, in the cypress repo: cypress `master-demo` must CONTAIN that pin and must NOT
+#   absorb any cypress-`master` commit NEWER than it (that would make the demo tests run
+#   ahead of the demo-shop version -> flaky/false failures).
+#
+# WHAT IT CHECKS (in the cypress repo, against the merge-base pin = TARGET):
+#   1. TARGET is an ancestor of cypress master-demo   (master-demo includes the pin)
+#   2. No commit reachable from master-demo and ahead of TARGET on cypress master
+#      leaked in                                       (master-demo is not ahead)
+#
+# USAGE:
+#   .claude/skills/upmerge-master-to-demo/check-cypress-not-ahead.sh
+#
+# ENV OVERRIDES (all optional — sane defaults below):
+#   DEMOSHOP_DIR     demo-shop repo root             (default: git toplevel of CWD)
+#   CYPRESS_DIR      cypress-tests checkout           (default: $DEMOSHOP_DIR/tests/cypress-tests)
+#   DEMOSHOP_MASTER  demo-shop master branch          (default: master)
+#   DEMOSHOP_DEMO    demo-shop demo branch            (default: master-demo)
+#   DEMOSHOP_REF     explicit demo-shop ref to read the pin from; OVERRIDES the
+#                    merge-base default (e.g. set to HEAD on the upmerge branch)
+#   CYPRESS_DEMO     cypress demo branch              (default: master-demo)
+#   CYPRESS_MASTER   cypress upstream branch          (default: origin/master)
+#   TARGET_HASH      override the pinned hash directly (default: read from composer.lock)
+#   NO_FETCH         set to 1 to skip `git fetch`      (default: fetch)
+#
+# EXIT CODES: 0 = gate passes, 1 = gate fails (ahead / pin missing), 2 = setup error.
+#
+# NOTE: this script requires bash (uses bash arrays/redirection). If invoked as
+# `sh check-cypress-not-ahead.sh` under a POSIX sh (dash), it re-execs itself with bash.
+
+# Re-exec under bash if we were started by a non-bash shell (e.g. `sh script.sh`).
+if [ -z "${BASH_VERSION:-}" ]; then
+  exec bash "$0" "$@"
+fi
+
+set -euo pipefail
+
+red()   { printf '\033[31m%s\033[0m\n' "$*"; }
+green() { printf '\033[32m%s\033[0m\n' "$*"; }
+yellow(){ printf '\033[33m%s\033[0m\n' "$*"; }
+bold()  { printf '\033[1m%s\033[0m\n'  "$*"; }
+dim()   { printf '\033[2m%s\033[0m\n'  "$*"; }
+rule()  { printf '\033[2m%s\033[0m\n'  "────────────────────────────────────────────────────────────────────"; }
+die()   { red "ERROR: $*"; exit 2; }
+
+# Show a commit as "<short> <subject>" or a friendly note if it can't be resolved.
+show_commit() { git -C "$CYPRESS_DIR" log --oneline -1 "$1" 2>/dev/null || echo "$1 (not resolvable)"; }
+
+DEMOSHOP_MASTER="${DEMOSHOP_MASTER:-master}"
+DEMOSHOP_DEMO="${DEMOSHOP_DEMO:-master-demo}"
+CYPRESS_DEMO="${CYPRESS_DEMO:-master-demo}"
+CYPRESS_MASTER="${CYPRESS_MASTER:-origin/master}"
+
+# Resolve the demo-shop repo root.
+if [ -n "${DEMOSHOP_DIR:-}" ]; then
+  DEMOSHOP_DIR="$(cd "$DEMOSHOP_DIR" && pwd)"
+else
+  DEMOSHOP_DIR="$(git -C "$(pwd)" rev-parse --show-toplevel 2>/dev/null)" \
+    || die "not inside a git repo and DEMOSHOP_DIR not set"
+  # If we're inside the cypress checkout, walk up to the demo-shop root.
+  case "$DEMOSHOP_DIR" in
+    */tests/cypress-tests) DEMOSHOP_DIR="${DEMOSHOP_DIR%/tests/cypress-tests}" ;;
+  esac
+fi
+CYPRESS_DIR="${CYPRESS_DIR:-$DEMOSHOP_DIR/tests/cypress-tests}"
+
+[ -f "$DEMOSHOP_DIR/composer.lock" ] || die "no composer.lock in demo-shop dir: $DEMOSHOP_DIR"
+[ -d "$CYPRESS_DIR/.git" ] || die "cypress checkout is not a git repo: $CYPRESS_DIR"
+
+# --- 1. Determine PIN_REF = the demo-shop ref whose composer.lock we read -------------
+# Default: the merge-base of master and master-demo = the latest MASTER version already
+# merged into master-demo. Override with DEMOSHOP_REF (e.g. HEAD) or TARGET_HASH.
+read_cypress_ref() {  # $1 = demo-shop git ref
+  git -C "$DEMOSHOP_DIR" show "$1:composer.lock" 2>/dev/null \
+    | python3 -c "import json,sys; d=json.load(sys.stdin); p=[x for x in d['packages']+d.get('packages-dev',[]) if x['name']=='spryker/cypress-tests']; sys.exit('spryker/cypress-tests not found in lock') if not p else print(p[0]['source']['reference'])"
+}
+
+if [ -n "${TARGET_HASH:-}" ]; then
+  PIN_REF="(TARGET_HASH override)"
+  TARGET="$TARGET_HASH"
+else
+  if [ -n "${DEMOSHOP_REF:-}" ]; then
+    PIN_REF="$DEMOSHOP_REF"
+  else
+    git -C "$DEMOSHOP_DIR" rev-parse --verify "$DEMOSHOP_MASTER" >/dev/null 2>&1 \
+      || die "demo-shop branch '$DEMOSHOP_MASTER' not found"
+    git -C "$DEMOSHOP_DIR" rev-parse --verify "$DEMOSHOP_DEMO" >/dev/null 2>&1 \
+      || die "demo-shop branch '$DEMOSHOP_DEMO' not found"
+    PIN_REF="$(git -C "$DEMOSHOP_DIR" merge-base "$DEMOSHOP_MASTER" "$DEMOSHOP_DEMO")" \
+      || die "could not compute merge-base of '$DEMOSHOP_MASTER' and '$DEMOSHOP_DEMO'"
+  fi
+  TARGET="$(read_cypress_ref "$PIN_REF")" \
+    || die "could not read spryker/cypress-tests reference from $PIN_REF:composer.lock"
+fi
+[ -n "$TARGET" ] || die "empty target hash"
+
+# --- 2. Make sure refs are present in the cypress repo (before we display anything) ---
+if [ "${NO_FETCH:-0}" != "1" ]; then
+  git -C "$CYPRESS_DIR" fetch origin --quiet || yellow "warning: git fetch failed, using local refs"
+fi
+git -C "$CYPRESS_DIR" cat-file -e "${TARGET}^{commit}" 2>/dev/null \
+  || die "target commit $TARGET not found in cypress repo (fetch it, or it is the wrong hash)"
+git -C "$CYPRESS_DIR" rev-parse --verify "$CYPRESS_DEMO" >/dev/null 2>&1 \
+  || die "cypress branch '$CYPRESS_DEMO' not found"
+git -C "$CYPRESS_DIR" rev-parse --verify "$CYPRESS_MASTER" >/dev/null 2>&1 \
+  || die "cypress branch '$CYPRESS_MASTER' not found"
+
+# Describe where the PIN came from, for the banner.
+if [ -n "${TARGET_HASH:-}" ]; then
+  PIN_SOURCE_DESC="explicit TARGET_HASH override"
+elif [ -n "${DEMOSHOP_REF:-}" ]; then
+  PIN_SOURCE_DESC="demo-shop ref '$DEMOSHOP_REF' (composer.lock)"
+else
+  PIN_SOURCE_DESC="merge-base of demo-shop '$DEMOSHOP_MASTER' & '$DEMOSHOP_DEMO' = latest master merged into '$DEMOSHOP_DEMO'"
+fi
+
+# --- 3. Banner: explain what we check and show the reference points -------------------
+rule
+bold "QUALITY GATE — is cypress '$CYPRESS_DEMO' in sync with the demo-shop's merged version?"
+rule
+echo "What this checks, in plain words:"
+echo "  demo-shop '$DEMOSHOP_DEMO' contains MASTER only up to where it was last upmerged,"
+echo "  NOT master's tip. The cypress version it should match is the one pinned by that"
+echo "  merged master point = git merge-base '$DEMOSHOP_MASTER' '$DEMOSHOP_DEMO' (the PIN)."
+echo "  Cypress '$CYPRESS_DEMO' must CONTAIN that PIN (else BEHIND),"
+echo "  and must NOT contain any cypress-'${CYPRESS_MASTER##*/}' commit NEWER than the PIN (else AHEAD)."
+echo "  AHEAD is the danger: the demo would run tests for shop code that doesn't exist yet."
+echo
+echo "Where the PIN comes from:"
+echo "  $PIN_SOURCE_DESC"
+if [ -z "${TARGET_HASH:-}" ] && [ -z "${DEMOSHOP_REF:-}" ]; then
+  printf '  %-38s : %s\n' "merged master commit (demo-shop)" "$(git -C "$DEMOSHOP_DIR" log --oneline -1 "$PIN_REF" 2>/dev/null)"
+fi
+echo
+echo "The reference points (in the cypress repo):"
+printf '  %-38s : %s\n' "PIN — cypress version that merged master pins" "$(show_commit "$TARGET")"
+printf '  %-38s : %s\n' "cypress '$CYPRESS_DEMO' tip"                    "$(show_commit "$CYPRESS_DEMO")"
+printf '  %-38s : %s\n' "cypress '$CYPRESS_MASTER' tip"                  "$(show_commit "$CYPRESS_MASTER")"
+echo
+echo "  Demo-only commits on '$CYPRESS_DEMO' (on top of the PIN — these are expected):"
+DEMO_ONLY="$(git -C "$CYPRESS_DIR" rev-list "$CYPRESS_DEMO" --not "$TARGET" "$CYPRESS_MASTER")"
+if [ -z "$DEMO_ONLY" ]; then
+  dim "    (none — '$CYPRESS_DEMO' is exactly at the PIN)"
+else
+  while IFS= read -r sha; do [ -n "$sha" ] && dim "    + $(show_commit "$sha")"; done <<< "$DEMO_ONLY"
+fi
+echo "  Commits on cypress '${CYPRESS_MASTER##*/}' that are NEWER than the PIN (must stay OUT of '$CYPRESS_DEMO'): $(git -C "$CYPRESS_DIR" rev-list --count "$TARGET..$CYPRESS_MASTER")"
+echo
+
+FAIL=0
+BEHIND=0
+AHEAD=0
+
+bold "Checks:"
+
+# --- Check 1: is the PIN contained in cypress master-demo? (not BEHIND) ----------------
+if git -C "$CYPRESS_DIR" merge-base --is-ancestor "$TARGET" "$CYPRESS_DEMO"; then
+  green "  [PASS] Check 1 — NOT BEHIND: the PIN is contained in '$CYPRESS_DEMO'."
+  dim   "         (the demo branch includes the cypress version the shop expects)"
+else
+  red   "  [FAIL] Check 1 — BEHIND: the PIN is NOT in '$CYPRESS_DEMO'."
+  dim   "         The demo branch is missing the commit the shop pins."
+  FAIL=1; BEHIND=1
+fi
+
+# --- Check 2: did any cypress-master commit NEWER than the PIN leak into master-demo? --
+# Set intersection: (commits in master-demo but not in PIN) ∩ (commits ahead of PIN on master)
+_tmp_md="$(mktemp)"; _tmp_ahead="$(mktemp)"
+trap 'rm -f "$_tmp_md" "$_tmp_ahead"' EXIT
+git -C "$CYPRESS_DIR" rev-list "$CYPRESS_DEMO" --not "$TARGET" | sort > "$_tmp_md"
+git -C "$CYPRESS_DIR" rev-list "$TARGET..$CYPRESS_MASTER"      | sort > "$_tmp_ahead"
+LEAK="$(comm -12 "$_tmp_md" "$_tmp_ahead")"
+LEAK_COUNT="$(printf '%s' "$LEAK" | grep -c . || true)"
+
+if [ "$LEAK_COUNT" -eq 0 ]; then
+  green "  [PASS] Check 2 — NOT AHEAD: no cypress-'${CYPRESS_MASTER##*/}' commit newer than the PIN is in '$CYPRESS_DEMO'."
+  dim   "         (the demo branch does not run ahead of the shop version)"
+else
+  red   "  [FAIL] Check 2 — AHEAD: $LEAK_COUNT cypress-'${CYPRESS_MASTER##*/}' commit(s) NEWER than the PIN are in '$CYPRESS_DEMO':"
+  while IFS= read -r sha; do
+    [ -n "$sha" ] && red "             $(show_commit "$sha")"
+  done <<< "$LEAK"
+  dim   "         These commits exist on cypress '${CYPRESS_MASTER##*/}' AFTER the PIN, but should not"
+  dim   "         be in the demo branch — they test shop code the merged demo-shop version doesn't have yet."
+  FAIL=1; AHEAD=1
+fi
+
+echo
+rule
+# --- Conclusion -----------------------------------------------------------------------
+if [ "$FAIL" -eq 0 ]; then
+  green "CONCLUSION: ✅ PASS"
+  echo  "  Cypress '$CYPRESS_DEMO' is exactly in sync with the merged demo-shop version's pin:"
+  echo  "  it contains the PIN and adds only demo-only commits on top — nothing ahead."
+  echo  "  Safe to push '$CYPRESS_DEMO' and re-pin the demo-shop to it (Step 6f-5)."
+  rule
+  exit 0
+fi
+
+red "CONCLUSION: ❌ FAIL"
+if [ "$BEHIND" -eq 1 ]; then
+  echo "  • BEHIND — '$CYPRESS_DEMO' does not contain the PIN."
+  echo "    FIX: merge the PIN hash into '$CYPRESS_DEMO' (Step 6f-3):"
+  echo "         cd $CYPRESS_DIR && git checkout $CYPRESS_DEMO && git merge $TARGET --no-ff"
+fi
+if [ "$AHEAD" -eq 1 ]; then
+  echo "  • AHEAD — '$CYPRESS_DEMO' contains $LEAK_COUNT commit(s) newer than the PIN (listed above)."
+  echo "    Cause: someone ran 'git merge ${CYPRESS_MASTER##*/}' instead of merging the PIN hash."
+  echo "    FIX: reset '$CYPRESS_DEMO' to its pre-merge tip, then re-merge the PIN HASH (not '${CYPRESS_MASTER##*/}'):"
+  echo "         cd $CYPRESS_DIR && git checkout $CYPRESS_DEMO && git merge $TARGET --no-ff"
+fi
+echo "  Do NOT push '$CYPRESS_DEMO' or re-pin the demo-shop until this gate is green."
+rule
+exit 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -388,6 +388,9 @@ jobs:
 
     docker-alpine-php-84-mariadb-robot-api-b2b:
         needs: [validation]
+        # Disabled: plain-B2B compatibility is not supported on master-demo. Kept defined
+        # (not deleted) so upstream edits to this job merge cleanly during upmerges.
+        if: false
         name: "Robot / API B2B"
         runs-on: ubuntu-latest
         env:
@@ -562,6 +565,9 @@ jobs:
 
     docker-alpine-php-84-mariadb-cypress-b2b:
         needs: [js-validation, validation]
+        # Disabled: plain-B2B compatibility is not supported on master-demo. Kept defined
+        # (not deleted) so upstream edits to this job merge cleanly during upmerges.
+        if: false
         name: "Cypress / UI B2B"
         runs-on: ubuntu-latest
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -477,14 +477,25 @@ jobs:
                 run: |
                     AWS_DEFAULT_REGION=${{env.ROBOT_TESTS_ARTIFACTS_BUCKET_REGION}} AWS_ACCESS_KEY_ID=${{ secrets.ROBOT_TESTS_ARTIFACTS_KEY }} AWS_SECRET_ACCESS_KEY=${{ secrets.ROBOT_TESTS_ARTIFACTS_SECRET }} aws s3 cp .cypress s3://${{vars.ROBOT_TESTS_ARTIFACTS_BUCKET}}/b2b-mp/dms-on/cypress/${GITHUB_RUN_ID}/PHP8.4MariaDB/ --recursive
 
+            -   name: Run Tests (Demo)
+                id: run_demo_tests
+                if: always()
+                run: |
+                    docker/sdk exec --env "ENV_REPOSITORY_ID=b2b-mp" --env "ENV_IS_SSP_ENABLED=true" cypress-tests npm run cy:demo
+
+            -   name: Upload Screenshots (Demo)
+                if: failure()
+                run: |
+                    AWS_DEFAULT_REGION=${{env.ROBOT_TESTS_ARTIFACTS_BUCKET_REGION}} AWS_ACCESS_KEY_ID=${{ secrets.ROBOT_TESTS_ARTIFACTS_KEY }} AWS_SECRET_ACCESS_KEY=${{ secrets.ROBOT_TESTS_ARTIFACTS_SECRET }} aws s3 cp .cypress s3://${{vars.ROBOT_TESTS_ARTIFACTS_BUCKET}}/b2b-mp/dms-on/cypress/${GITHUB_RUN_ID}/PHP8.4MariaDB/ --recursive
+
             -   name: Generate Cypress Test Summary
-                if: always() && (steps.run_tests.outcome == 'failure' || steps.run_ssp_tests.outcome == 'failure')
+                if: always() && (steps.run_tests.outcome == 'failure' || steps.run_ssp_tests.outcome == 'failure' || steps.run_demo_tests.outcome == 'failure')
                 run: |
                     python3 tests/cypress-tests/generate_failure_summary.py .cypress > /tmp/cypress-summary.md 2>/dev/null || true
                     cat /tmp/cypress-summary.md >> $GITHUB_STEP_SUMMARY 2>/dev/null || true
 
             -   name: Save PHP logs
-                if: always() && (steps.run_tests.outcome == 'failure' || steps.run_ssp_tests.outcome == 'failure')
+                if: always() && (steps.run_tests.outcome == 'failure' || steps.run_ssp_tests.outcome == 'failure' || steps.run_demo_tests.outcome == 'failure')
                 run: |
                     mkdir -p logs
                     docker logs spryker_ci_backoffice_eu_1 > logs/backoffice_app.log 2>&1
@@ -495,7 +506,7 @@ jobs:
                     echo "PHP logs saved. After upload, they will be available in GitHub Actions Artifacts as 'cypress-ui-failed-artifacts'"
 
             -   name: Upload PHP logs
-                if: always() && (steps.run_tests.outcome == 'failure' || steps.run_ssp_tests.outcome == 'failure')
+                if: always() && (steps.run_tests.outcome == 'failure' || steps.run_ssp_tests.outcome == 'failure' || steps.run_demo_tests.outcome == 'failure')
                 uses: actions/upload-artifact@v5
                 with:
                     name: cypress-ui-failed-artifacts

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,6 +125,47 @@ jobs:
                 uses: ./.github/actions/job-slack-notifications
                 if: always()
 
+    cypress-version-gate:
+        name: "Cypress demo branch not ahead of pin"
+        if: ${{ !(github.event_name == 'push' && github.ref == 'refs/heads/master') }}
+        runs-on: ubuntu-latest
+        steps:
+            # Full history so merge-base(master, HEAD) and the demo-shop lock are readable.
+            -   name: Checkout demo-shop
+                uses: actions/checkout@v4
+                with:
+                    fetch-depth: 0
+
+            # PR checkout has no local 'master'; the gate's PIN = merge-base(master, HEAD),
+            # so fetch the demo-shop master branch as a local ref it can resolve.
+            -   name: Fetch demo-shop master
+                run: git fetch origin master:master
+
+            # The cypress-tests checkout under tests/ is a composer dist (zip) install in CI,
+            # so it has no .git. Clone the cypress repo fresh, read-only, for the gate.
+            -   name: Clone spryker/cypress-tests (master + master-demo)
+                run: |
+                    git clone --no-checkout https://github.com/spryker/cypress-tests.git /tmp/cypress-tests
+                    git -C /tmp/cypress-tests fetch origin master master-demo
+
+            # bash + python3 are preinstalled on ubuntu-latest; the script self-execs under bash.
+            # PIN = cypress hash the MERGED demo-shop version pins = merge-base(master, HEAD).
+            # This is the master-line hash (NOT the PR's own lock, which would be circular).
+            # Gate fails if cypress master-demo is BEHIND or AHEAD of that PIN.
+            -   name: Run cypress version gate
+                env:
+                    DEMOSHOP_MASTER: master
+                    DEMOSHOP_DEMO: HEAD
+                    CYPRESS_DIR: /tmp/cypress-tests
+                    CYPRESS_DEMO: origin/master-demo
+                    CYPRESS_MASTER: origin/master
+                    NO_FETCH: "1"
+                run: bash .claude/skills/upmerge-master-to-demo/check-cypress-not-ahead.sh
+
+            -   name: Slack Notification for failed job
+                uses: ./.github/actions/job-slack-notifications
+                if: always()
+
     js-validation:
         name: "NPM validation"
         runs-on: ubuntu-latest

--- a/composer.json
+++ b/composer.json
@@ -391,7 +391,7 @@
         "spryker-sdk/phpstan-spryker": "^0.5.1",
         "spryker/architecture-sniffer": "^0.5.10",
         "spryker/code-sniffer": "^0.17.31",
-        "spryker/cypress-tests": "dev-master",
+        "spryker/cypress-tests": "dev-feature/cc-39427/smoke-test-master-demo",
         "spryker/profiler": "^0.1.3",
         "spryker/robotframework-suite-tests": "dev-master",
         "spryker/testify": "^3.64.0",

--- a/composer.json
+++ b/composer.json
@@ -391,7 +391,7 @@
         "spryker-sdk/phpstan-spryker": "^0.5.1",
         "spryker/architecture-sniffer": "^0.5.10",
         "spryker/code-sniffer": "^0.17.31",
-        "spryker/cypress-tests": "dev-feature/cc-39427/smoke-test-master-demo",
+        "spryker/cypress-tests": "dev-master-demo",
         "spryker/profiler": "^0.1.3",
         "spryker/robotframework-suite-tests": "dev-master",
         "spryker/testify": "^3.64.0",

--- a/composer.lock
+++ b/composer.lock
@@ -92143,14 +92143,14 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker/cypress-tests.git",
-                "reference": "6a6e5412d4fcb22577f5290483d37a3aa4a9406a"
+                "reference": "696e3ff20dd7713430eabe1b22f4a73d2b3ad1b6"
             },
             "type": "spryker-test",
             "license": [
                 "MIT"
             ],
             "description": "This repository is dedicated to housing an extensive collection of UI end-to-end tests, meticulously crafted using Cypress for Spryker applications. These tests are designed to thoroughly evaluate the user interface, ensuring that all interactions and visual elements function as intended in real-world scenarios. By leveraging Cypress's advanced browser automation capabilities, this suite provides an efficient and effective means of validating the user experience, confirming the seamless operation and aesthetic integrity of Spryker's front-end components. Our commitment to rigorous UI testing helps maintain the high standard of quality and reliability that Spryker users expect.",
-            "time": "2026-06-27T18:16:55+00:00"
+            "time": "2026-06-27T19:28:30+00:00"
         },
         {
             "name": "spryker/development",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c750e16923419ebb37d60ab26a7f2f47",
+    "content-hash": "aec391960203ed4d64bd2655817f9e68",
     "packages": [
         {
             "name": "algolia/algoliasearch-client-php",
@@ -92139,19 +92139,18 @@
         },
         {
             "name": "spryker/cypress-tests",
-            "version": "dev-master",
+            "version": "dev-feature/cc-39427/smoke-test-master-demo",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker/cypress-tests.git",
-                "reference": "09e6cbcfaa2c01c9986d839ed4b9e3e4ff3ec3e1"
+                "reference": "0a13b356506143e681e4f0bde42295677b17af00"
             },
-            "default-branch": true,
             "type": "spryker-test",
             "license": [
                 "MIT"
             ],
             "description": "This repository is dedicated to housing an extensive collection of UI end-to-end tests, meticulously crafted using Cypress for Spryker applications. These tests are designed to thoroughly evaluate the user interface, ensuring that all interactions and visual elements function as intended in real-world scenarios. By leveraging Cypress's advanced browser automation capabilities, this suite provides an efficient and effective means of validating the user experience, confirming the seamless operation and aesthetic integrity of Spryker's front-end components. Our commitment to rigorous UI testing helps maintain the high standard of quality and reliability that Spryker users expect.",
-            "time": "2026-06-15T18:10:16+00:00"
+            "time": "2026-06-26T08:46:45+00:00"
         },
         {
             "name": "spryker/development",

--- a/composer.lock
+++ b/composer.lock
@@ -92143,14 +92143,14 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker/cypress-tests.git",
-                "reference": "0a13b356506143e681e4f0bde42295677b17af00"
+                "reference": "01d6d88344bb1a607d13a07e1057b17e14b6522f"
             },
             "type": "spryker-test",
             "license": [
                 "MIT"
             ],
             "description": "This repository is dedicated to housing an extensive collection of UI end-to-end tests, meticulously crafted using Cypress for Spryker applications. These tests are designed to thoroughly evaluate the user interface, ensuring that all interactions and visual elements function as intended in real-world scenarios. By leveraging Cypress's advanced browser automation capabilities, this suite provides an efficient and effective means of validating the user experience, confirming the seamless operation and aesthetic integrity of Spryker's front-end components. Our commitment to rigorous UI testing helps maintain the high standard of quality and reliability that Spryker users expect.",
-            "time": "2026-06-26T08:46:45+00:00"
+            "time": "2026-06-26T15:07:46+00:00"
         },
         {
             "name": "spryker/development",
@@ -93069,5 +93069,5 @@
     "platform-overrides": {
         "php": "8.3.13"
     },
-    "plugin-api-version": "2.9.0"
+    "plugin-api-version": "2.6.0"
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "aec391960203ed4d64bd2655817f9e68",
+    "content-hash": "c80424c40ed0b6ed4fe42f6105b7c488",
     "packages": [
         {
             "name": "algolia/algoliasearch-client-php",
@@ -92139,18 +92139,18 @@
         },
         {
             "name": "spryker/cypress-tests",
-            "version": "dev-feature/cc-39427/smoke-test-master-demo",
+            "version": "dev-master-demo",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker/cypress-tests.git",
-                "reference": "01d6d88344bb1a607d13a07e1057b17e14b6522f"
+                "reference": "6a6e5412d4fcb22577f5290483d37a3aa4a9406a"
             },
             "type": "spryker-test",
             "license": [
                 "MIT"
             ],
             "description": "This repository is dedicated to housing an extensive collection of UI end-to-end tests, meticulously crafted using Cypress for Spryker applications. These tests are designed to thoroughly evaluate the user interface, ensuring that all interactions and visual elements function as intended in real-world scenarios. By leveraging Cypress's advanced browser automation capabilities, this suite provides an efficient and effective means of validating the user experience, confirming the seamless operation and aesthetic integrity of Spryker's front-end components. Our commitment to rigorous UI testing helps maintain the high standard of quality and reliability that Spryker users expect.",
-            "time": "2026-06-26T15:07:46+00:00"
+            "time": "2026-06-27T18:16:55+00:00"
         },
         {
             "name": "spryker/development",

--- a/src/Pyz/Yves/AiCommerce/AiCommerceConfig.php
+++ b/src/Pyz/Yves/AiCommerce/AiCommerceConfig.php
@@ -14,11 +14,6 @@ use SprykerFeature\Yves\AiCommerce\AiCommerceConfig as SprykerAiCommerceConfig;
 
 class AiCommerceConfig extends SprykerAiCommerceConfig
 {
-    public function isQuickOrderImageToCartEnabled(): bool
-    {
-        return true;
-    }
-
     /**
      * Specification:
      * - Returns the AI configuration name used for image-to-cart product recognition.


### PR DESCRIPTION
- Update upmerge skill documentation to mandate running the demo Cypress group (`cy:demo`) after smoke testing.
- Ensure `cy:demo` coverage for demo-only features (e.g., QuickSight Analytics) and dropped demo-specific configs in `config_default.php`.
- Add `Run Tests (Demo)` CI step for isolated demo test execution with independent reporting.
- Adjust `composer.json` to use `dev-feature/cc-39427/smoke-test-master-demo` branch of `spryker/cypress-tests`.
- Refresh `composer.lock` to reflect dependency changes.

Refs CC-39427

#### Overview

- Ticket: URL_HERE

###### Change log

{Relevant changes for project level go here.}

###### CI Notice
**Additional tests** can be triggered by adding labels:
- `run-compatibility-ci` runs compatibility tests (PHP 8.3 / PostgreSQL / Debian / Prefer Lowest / Dynamic Store OFF):
    - Codeception / Acceptance & API
    - Codeception / Functional Tests
    - Robot / API
    - Robot / UI
    - Cypress / UI
