### PR TITLE
ci(robot-ui): always upload PHP logs & report artifacts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -719,7 +719,7 @@ jobs:
                     cat /tmp/robot-summary.md >> $GITHUB_STEP_SUMMARY 2>/dev/null || true
 
             -   name: Save PHP logs
-                if: always() && (steps.rerun_failed_tests.outcome == 'skipped' || steps.rerun_failed_tests.outcome == 'failure')
+                if: always()
                 run: |
                     mkdir -p logs
                     docker logs spryker_ci_backoffice_eu_1 > logs/backoffice_app.log 2>&1
@@ -729,13 +729,13 @@ jobs:
                     docker logs spryker_ci_glue_backend_eu_1 > logs/glue_backend_eu.log 2>&1 || true
                     mkdir -p robot-results
                     cp -r .robot/results/* robot-results/ 2>/dev/null || true
-                    echo "PHP logs saved. After upload, they will be available in GitHub Actions Artifacts as 'robot-ui-failed-artifacts'"
+                    echo "PHP logs saved. After upload, they will be available in GitHub Actions Artifacts as 'robot-ui-artifacts'"
 
             -   name: Upload PHP logs & report
-                if: always() && (steps.rerun_failed_tests.outcome == 'skipped' || steps.rerun_failed_tests.outcome == 'failure')
+                if: always()
                 uses: actions/upload-artifact@v5
                 with:
-                    name: robot-ui-failed-artifacts
+                    name: robot-ui-artifacts
                     retention-days: 5 # save for 5 days
                     path: |
                         logs/*.log


### PR DESCRIPTION
## What

Make the **Robot / UI** CI job (`docker-alpine-php-84-mariadb-robot-ui`) always collect and upload its PHP logs and Robot report, instead of only when tests fail.

## Why

Previously the *Save PHP logs* and *Upload PHP logs & report* steps were gated on `steps.rerun_failed_tests.outcome == 'skipped' || 'failure'`, so on green (or otherwise non-failing) runs no logs/report were uploaded. That makes it hard to inspect Robot output for passing-but-suspicious runs.

## Changes

- Both steps now use `if: always()` so logs + report upload on every run.
- Artifact renamed `robot-ui-failed-artifacts` -> `robot-ui-artifacts` (no longer failure-only), including the echoed message.

## Notes

- The Robot test steps use `continue-on-error: true`, so `.robot/results/*` is produced regardless of pass/fail.