### PR TITLE
fix(error-handler): respect @ suppression + always upload robot-ui logs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -719,7 +719,7 @@ jobs:
                     cat /tmp/robot-summary.md >> $GITHUB_STEP_SUMMARY 2>/dev/null || true
 
             -   name: Save PHP logs
-                if: always() && (steps.rerun_failed_tests.outcome == 'skipped' || steps.rerun_failed_tests.outcome == 'failure')
+                if: always()
                 run: |
                     mkdir -p logs
                     docker logs spryker_ci_backoffice_eu_1 > logs/backoffice_app.log 2>&1
@@ -729,13 +729,13 @@ jobs:
                     docker logs spryker_ci_glue_backend_eu_1 > logs/glue_backend_eu.log 2>&1 || true
                     mkdir -p robot-results
                     cp -r .robot/results/* robot-results/ 2>/dev/null || true
-                    echo "PHP logs saved. After upload, they will be available in GitHub Actions Artifacts as 'robot-ui-failed-artifacts'"
+                    echo "PHP logs saved. After upload, they will be available in GitHub Actions Artifacts as 'robot-ui-artifacts'"
 
             -   name: Upload PHP logs & report
-                if: always() && (steps.rerun_failed_tests.outcome == 'skipped' || steps.rerun_failed_tests.outcome == 'failure')
+                if: always()
                 uses: actions/upload-artifact@v5
                 with:
-                    name: robot-ui-failed-artifacts
+                    name: robot-ui-artifacts
                     retention-days: 5 # save for 5 days
                     path: |
                         logs/*.log

--- a/public/BackendGateway/index.php
+++ b/public/BackendGateway/index.php
@@ -1,7 +1,9 @@
 <?php
 
+declare(strict_types = 1);
+
+use Pyz\Shared\ErrorHandler\ErrorHandlerEnvironment;
 use Spryker\Shared\Config\Application\Environment;
-use Spryker\Shared\ErrorHandler\ErrorHandlerEnvironment;
 use Spryker\Zed\Application\Communication\Bootstrap\BackendGatewayBootstrap;
 
 define('APPLICATION', 'ZED');

--- a/public/Backoffice/index.php
+++ b/public/Backoffice/index.php
@@ -1,7 +1,9 @@
 <?php
 
+declare(strict_types = 1);
+
+use Pyz\Shared\ErrorHandler\ErrorHandlerEnvironment;
 use Spryker\Shared\Config\Application\Environment;
-use Spryker\Shared\ErrorHandler\ErrorHandlerEnvironment;
 use Spryker\Zed\Application\Communication\Bootstrap\BackofficeBootstrap;
 
 require __DIR__ . '/maintenance/maintenance.php';

--- a/public/Glue/index.php
+++ b/public/Glue/index.php
@@ -1,8 +1,10 @@
 <?php
 
+declare(strict_types = 1);
+
 use Pyz\Glue\GlueApplication\Bootstrap\GlueBootstrap;
+use Pyz\Shared\ErrorHandler\ErrorHandlerEnvironment;
 use Spryker\Shared\Config\Application\Environment;
-use Spryker\Shared\ErrorHandler\ErrorHandlerEnvironment;
 
 define('APPLICATION', 'GLUE');
 defined('APPLICATION_ROOT_DIR') || define('APPLICATION_ROOT_DIR', dirname(__DIR__, 2));

--- a/public/GlueBackend/index.php
+++ b/public/GlueBackend/index.php
@@ -1,8 +1,10 @@
 <?php
 
+declare(strict_types = 1);
+
 use Pyz\Glue\GlueApplication\Bootstrap\GlueBackendApiBootstrap;
+use Pyz\Shared\ErrorHandler\ErrorHandlerEnvironment;
 use Spryker\Shared\Config\Application\Environment;
-use Spryker\Shared\ErrorHandler\ErrorHandlerEnvironment;
 
 define('APPLICATION', 'GLUE_BACKEND');
 defined('APPLICATION_ROOT_DIR') || define('APPLICATION_ROOT_DIR', dirname(__DIR__, 2));

--- a/public/MerchantPortal/index.php
+++ b/public/MerchantPortal/index.php
@@ -1,8 +1,10 @@
 <?php
 
+declare(strict_types = 1);
+
+use Pyz\Shared\ErrorHandler\ErrorHandlerEnvironment;
 use Pyz\Zed\MerchantPortalApplication\Communication\Bootstrap\MerchantPortalBootstrap;
 use Spryker\Shared\Config\Application\Environment;
-use Spryker\Shared\ErrorHandler\ErrorHandlerEnvironment;
 
 define('APPLICATION', 'MERCHANT_PORTAL');
 defined('APPLICATION_ROOT_DIR') || define('APPLICATION_ROOT_DIR', dirname(__DIR__, 2));

--- a/public/Yves/index.php
+++ b/public/Yves/index.php
@@ -1,8 +1,10 @@
 <?php
 
+declare(strict_types = 1);
+
+use Pyz\Shared\ErrorHandler\ErrorHandlerEnvironment;
 use Pyz\Yves\ShopApplication\YvesBootstrap;
 use Spryker\Shared\Config\Application\Environment;
-use Spryker\Shared\ErrorHandler\ErrorHandlerEnvironment;
 
 require __DIR__ . '/maintenance/maintenance.php';
 

--- a/public/Zed/index.php
+++ b/public/Zed/index.php
@@ -1,8 +1,10 @@
 <?php
 
+declare(strict_types = 1);
+
+use Pyz\Shared\ErrorHandler\ErrorHandlerEnvironment;
 use Pyz\Zed\Application\Communication\ZedBootstrap;
 use Spryker\Shared\Config\Application\Environment;
-use Spryker\Shared\ErrorHandler\ErrorHandlerEnvironment;
 
 require __DIR__ . '/maintenance/maintenance.php';
 

--- a/src/Pyz/Shared/ErrorHandler/ErrorHandlerEnvironment.php
+++ b/src/Pyz/Shared/ErrorHandler/ErrorHandlerEnvironment.php
@@ -1,0 +1,54 @@
+<?php
+
+/**
+ * This file is part of the Spryker Commerce OS.
+ * For full license information, please view the LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types = 1);
+
+namespace Pyz\Shared\ErrorHandler;
+
+use ErrorException;
+use Spryker\Shared\Config\Config;
+use Spryker\Shared\ErrorHandler\ErrorHandlerConstants;
+use Spryker\Shared\ErrorHandler\ErrorHandlerEnvironment as SprykerErrorHandlerEnvironment;
+use Spryker\Shared\ErrorHandler\ErrorLogger;
+
+class ErrorHandlerEnvironment extends SprykerErrorHandlerEnvironment
+{
+    /**
+     * Unlike the core error handler, respects the `@` error suppression operator: PHP still invokes
+     * a registered error handler for suppressed errors and signals suppression only through a reduced
+     * `error_reporting()` mask. Vendor code relies on this contract for benign failures, e.g. the
+     * `@mkdir()` race guard in `\Symfony\Component\Cache\Traits\FilesystemCommonTrait`, which the core
+     * handler escalates to a fatal `ErrorException` under concurrent requests.
+     *
+     * @throws \ErrorException
+     *
+     * @return void
+     */
+    protected function setErrorHandler(): void
+    {
+        $errorLevel = error_reporting();
+        $errorHandler = function (int $severity, string $message, string $file, int $line): bool {
+            if ((error_reporting() & $severity) === 0) {
+                return false;
+            }
+
+            $exception = new ErrorException($message, 0, $severity, $file, $line);
+
+            $levelsNotThrowingExceptions = Config::get(ErrorHandlerConstants::ERROR_LEVEL_LOG_ONLY, 0);
+            $shouldThrowException = ($severity & $levelsNotThrowingExceptions) === 0;
+            if ($shouldThrowException) {
+                throw $exception;
+            }
+
+            ErrorLogger::getInstance()->log($exception);
+
+            return true;
+        };
+
+        set_error_handler($errorHandler, $errorLevel);
+    }
+}


### PR DESCRIPTION
Combines two changes.

## 1. ErrorHandler fix — respect `@` suppression

Adds `Pyz\Shared\ErrorHandler\ErrorHandlerEnvironment` overriding the core error handler so it honors the `@` suppression operator. When `error_reporting()` is reduced (a suppressed error), the handler returns instead of escalating to a fatal `ErrorException`.

**Why:** vendor code relies on `@` for benign failures — e.g. the `@mkdir()` race guard in Symfony's `FilesystemCommonTrait`, which the core handler turns into a fatal error under concurrent requests.

All public entrypoints (Yves, Zed, Backoffice, BackendGateway, Glue, GlueBackend, MerchantPortal) now use the Pyz implementation and declare `strict_types`.

## 2. CI — always upload Robot / UI logs

The **Robot / UI** job's *Save PHP logs* and *Upload PHP logs & report* steps now run with `if: always()` instead of only on failure, so logs + the Robot report are available for every run. Artifact renamed `robot-ui-failed-artifacts` -> `robot-ui-artifacts`.

---
Related: #1209 (the robot-logs-only change on its own).