### PR TITLE
SUPECS-1122: update spryker/error-handler to 2.15.0

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -41053,16 +41053,16 @@
         },
         {
             "name": "spryker/error-handler",
-            "version": "2.14.1",
+            "version": "2.15.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker/error-handler.git",
-                "reference": "25d349e7b9df42b22fc307bcc4aeb8d6ebdf62fd"
+                "reference": "d8cd1c7e2f3c2670c609f52233c30e0d729dc7f1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker/error-handler/zipball/25d349e7b9df42b22fc307bcc4aeb8d6ebdf62fd",
-                "reference": "25d349e7b9df42b22fc307bcc4aeb8d6ebdf62fd",
+                "url": "https://api.github.com/repos/spryker/error-handler/zipball/d8cd1c7e2f3c2670c609f52233c30e0d729dc7f1",
+                "reference": "d8cd1c7e2f3c2670c609f52233c30e0d729dc7f1",
                 "shasum": ""
             },
             "require": {
@@ -41109,9 +41109,9 @@
             ],
             "description": "ErrorHandler module",
             "support": {
-                "source": "https://github.com/spryker/error-handler/tree/2.14.1"
+                "source": "https://github.com/spryker/error-handler/tree/2.15.0"
             },
-            "time": "2026-02-24T16:13:12+00:00"
+            "time": "2026-07-06T13:50:05+00:00"
         },
         {
             "name": "spryker/error-handler-extension",


### PR DESCRIPTION
- Bump version from 2.14.1 to 2.15.0.
- Update references and metadata in `composer.lock`.

#### Overview

- Ticket: https://spryker.atlassian.net/browse/SUPESC-1122

###### Change log

{Relevant changes for project level go here.}

###### CI Notice
**Additional tests** can be triggered by adding labels:
- `run-compatibility-ci` runs compatibility tests (PHP 8.3 / PostgreSQL / Debian / Prefer Lowest / Dynamic Store OFF):
    - Codeception / Acceptance & API
    - Codeception / Functional Tests
    - Robot / API
    - Robot / UI
    - Cypress / UI
