### PR TITLE
CC-39610: integrate AiCommerce package updates (Smart PIM prompts config + BO Assistant TypeError fix)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "spryker-eco/vertex": "^1.4.0",
         "spryker-feature/acl": "^202606.0",
         "spryker-feature/agent-assist": "^202606.0",
-        "spryker-feature/ai-commerce": "^202606.0",
+        "spryker-feature/ai-commerce": "dev-master as 202606.0",
         "spryker-feature/alternative-products": "^202606.0",
         "spryker-feature/analytics": "^202606.0",
         "spryker-feature/approval-process": "^202606.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c41cb85d5e401485cf652cc470d65d08",
+    "content-hash": "7f0354a54788abe6d6d6e2ffac40a47b",
     "packages": [
         {
             "name": "algolia/algoliasearch-client-php",
@@ -10287,16 +10287,16 @@
         },
         {
             "name": "spryker-feature/ai-commerce",
-            "version": "202606.0",
+            "version": "dev-master",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker-feature/ai-commerce.git",
-                "reference": "120570973e2cf25b7996e34af5f16e5507d2ec22"
+                "reference": "f9bbb92eed2d505e504b5fc7149554a4367c91a5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker-feature/ai-commerce/zipball/120570973e2cf25b7996e34af5f16e5507d2ec22",
-                "reference": "120570973e2cf25b7996e34af5f16e5507d2ec22",
+                "url": "https://api.github.com/repos/spryker-feature/ai-commerce/zipball/f9bbb92eed2d505e504b5fc7149554a4367c91a5",
+                "reference": "f9bbb92eed2d505e504b5fc7149554a4367c91a5",
                 "shasum": ""
             },
             "require": {
@@ -10346,6 +10346,7 @@
                 "spryker/router": "Required for SearchByImageRouteProviderPlugin to register search by image routes in Yves.",
                 "spryker/twig": "When using AiCommerceTwigPlugin"
             },
+            "default-branch": true,
             "type": "library",
             "extra": {
                 "branch-alias": {
@@ -10363,9 +10364,9 @@
             ],
             "description": "AiCommerce module",
             "support": {
-                "source": "https://github.com/spryker-feature/ai-commerce/tree/202606.0"
+                "source": "https://github.com/spryker-feature/ai-commerce/tree/master"
             },
-            "time": "2026-06-16T14:23:52+00:00"
+            "time": "2026-07-10T11:55:56+00:00"
         },
         {
             "name": "spryker-feature/alternative-products",
@@ -25684,16 +25685,16 @@
         },
         {
             "name": "spryker/ai-foundation",
-            "version": "0.8.2",
+            "version": "0.8.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker/ai-foundation.git",
-                "reference": "cc7c309c40b2e2458dba5db3216fbdecb4e1efe8"
+                "reference": "a4e22557a54a866ea535d22c0baa1fee5c092e08"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker/ai-foundation/zipball/cc7c309c40b2e2458dba5db3216fbdecb4e1efe8",
-                "reference": "cc7c309c40b2e2458dba5db3216fbdecb4e1efe8",
+                "url": "https://api.github.com/repos/spryker/ai-foundation/zipball/a4e22557a54a866ea535d22c0baa1fee5c092e08",
+                "reference": "a4e22557a54a866ea535d22c0baa1fee5c092e08",
                 "shasum": ""
             },
             "require": {
@@ -25737,9 +25738,9 @@
             ],
             "description": "AiFoundation module",
             "support": {
-                "source": "https://github.com/spryker/ai-foundation/tree/0.8.2"
+                "source": "https://github.com/spryker/ai-foundation/tree/0.8.3"
             },
-            "time": "2026-06-12T10:49:29+00:00"
+            "time": "2026-07-10T12:41:08+00:00"
         },
         {
             "name": "spryker/alternative-products-rest-api",
@@ -93083,9 +93084,17 @@
             "time": "2025-12-08T11:19:18+00:00"
         }
     ],
-    "aliases": [],
+    "aliases": [
+        {
+            "package": "spryker-feature/ai-commerce",
+            "version": "9999999-dev",
+            "alias": "202606.0",
+            "alias_normalized": "202606.0"
+        }
+    ],
     "minimum-stability": "dev",
     "stability-flags": {
+        "spryker-feature/ai-commerce": 20,
         "spryker/cypress-tests": 20,
         "spryker/robotframework-suite-tests": 20
     },


### PR DESCRIPTION
#### Overview

- Ticket: https://spryker.atlassian.net/browse/CC-39610
- Ticket: https://spryker.atlassian.net/browse/CC-38802

Integrates two `spryker/suite` PRs into the demoshop (master):
- suite#901 (CC-39610) — Fix `TypeError` loading Back Office Assistant chat history (`spryker/ai-foundation` patch).
- suite#889 (CC-38802) — Make AiCommerce prompts (Smart PIM, Search by Image, Visual Add-to-Cart) configurable via Configuration Management (`spryker-feature/ai-commerce`).

###### Change log

- Updated feature packages: `spryker-feature/ai-commerce` → `dev-master as 202606.0`.
  - Lock changes: `spryker-feature/ai-commerce` 202606.0 → dev-master, `spryker/ai-foundation` 0.8.2 → 0.8.3.
- Packages added directly: none.
- Project changes applied from suite PRs: none — all changed files are vendor (`src/Spryker`, `src/SprykerFeature`) released via composer.
- Conflicts requiring manual review: none.

###### CI Notice
**Additional tests** can be triggered by adding labels:
- `run-compatibility-ci` runs compatibility tests (PHP 8.3 / PostgreSQL / Debian / Prefer Lowest / Dynamic Store OFF):
    - Codeception / Acceptance & API
    - Codeception / Functional Tests
    - Robot / API
    - Robot / UI
    - Cypress / UI