### PR TITLE
CC-39662: Preserve CMS content widgets in Smart CMS content generation

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -10291,12 +10291,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker-feature/ai-commerce.git",
-                "reference": "f9bbb92eed2d505e504b5fc7149554a4367c91a5"
+                "reference": "dbc82812162051247b71a0ec3c01a656877e6562"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker-feature/ai-commerce/zipball/f9bbb92eed2d505e504b5fc7149554a4367c91a5",
-                "reference": "f9bbb92eed2d505e504b5fc7149554a4367c91a5",
+                "url": "https://api.github.com/repos/spryker-feature/ai-commerce/zipball/dbc82812162051247b71a0ec3c01a656877e6562",
+                "reference": "dbc82812162051247b71a0ec3c01a656877e6562",
                 "shasum": ""
             },
             "require": {
@@ -10366,7 +10366,7 @@
             "support": {
                 "source": "https://github.com/spryker-feature/ai-commerce/tree/master"
             },
-            "time": "2026-07-10T11:55:56+00:00"
+            "time": "2026-07-21T07:56:12+00:00"
         },
         {
             "name": "spryker-feature/alternative-products",


### PR DESCRIPTION
#### Overview

- Ticket: https://spryker.atlassian.net/browse/CC-39662
- Suite PR: https://github.com/spryker/suite/pull/929

###### Change log

- Updated feature package: `spryker-feature/ai-commerce` (`dev-master as 202606.0`) — picks up the `SmartCmsContentItemHtmlCollapser` improvement that preserves CMS content widgets during Smart CMS content generation.
- Packages added directly: none
- Project changes applied from suite PR 929: 0 files (all changes live under `src/SprykerFeature/AiCommerce/` and ship via the released package)
- Conflicts requiring manual review: 0 files

`composer.lock` diff is minimal — only the `spryker-feature/ai-commerce` reference (`f9bbb92` → `dbc8281`). `plugin-api-version` preserved at `2.9.0`.

###### CI Notice
**Additional tests** can be triggered by adding labels:
- `run-compatibility-ci` runs compatibility tests (PHP 8.3 / PostgreSQL / Debian / Prefer Lowest / Dynamic Store OFF):
    - Codeception / Acceptance & API
    - Codeception / Functional Tests
    - Robot / API
    - Robot / UI
    - Cypress / UI