### PR TITLE
CC-39748 Storefront. Product set. Image for the opened product set is absent

### DIFF
--- a/src/Pyz/Yves/ProductSetDetailPage/Theme/default/views/set-detail/set-detail.twig
+++ b/src/Pyz/Yves/ProductSetDetailPage/Theme/default/views/set-detail/set-detail.twig
@@ -4,7 +4,24 @@
     metaTitle: _view.productSet.metaTitle,
 } %}
 
-{% block pageInfo %}{% endblock %}
+{% block pageInfo %}
+    <div class="page-info">
+        <div class="container">
+            {% block breadcrumbs %}
+                {% include molecule('breadcrumb') with {
+                    data: {
+                        steps: [
+                            {
+                                label: 'product.sets' | trans,
+                                url: url('product-sets')
+                            },
+                        ]
+                    }
+                } only %}
+            {% endblock %}
+        </div>
+    </div>
+{% endblock %}
 
 {% block content %}
     {% set images = [] %}

--- a/src/Pyz/Yves/ProductSetDetailPage/Theme/default/views/set-detail/set-detail.twig
+++ b/src/Pyz/Yves/ProductSetDetailPage/Theme/default/views/set-detail/set-detail.twig
@@ -48,28 +48,30 @@
             } only %}
                 {% block slides %}
                     {% for image in embed.images %}
-                        {% embed molecule('banner') with {
-                            class: embed.configName,
-                            data: {
-                                imageUrl: image,
-                                title: embed.title,
-                            },
-                        } only %}
-                            {% block content %}
-                                <h1 class="title title--light title--product-set-details">{{ data.title }}</h1>
-                                <p class="{{ config.name }}__text {{ config.name }}__text--subtitle">
-                                    {{- 'product.set' | trans -}}
-                                </p>
-                            {% endblock %}
+                        <div>
+                            {% embed molecule('banner') with {
+                                class: embed.configName,
+                                data: {
+                                    imageUrl: image,
+                                    title: embed.title,
+                                },
+                            } only %}
+                                {% block content %}
+                                    <h1 class="{{ config.name }}__title">{{ data.title }}</h1>
+                                    <p class="{{ config.name }}__text {{ config.name }}__text--subtitle">
+                                        {{- 'product.set' | trans -}}
+                                    </p>
+                                {% endblock %}
 
-                            {% block body %}
-                                {% set containerClass = config.name ~ '__container grid grid--column grid--middle grid--center' %}
-                                {# default('') must bind to contentClass (undefined here); the | filter has higher precedence than ~, so keep it directly on the variable #}
-                                {% set contentClass = contentClass | default('') ~ ' ' ~ 'text-center' %}
+                                {% block body %}
+                                    {% set containerClass = config.name ~ '__container grid grid--column grid--middle grid--center' %}
+                                    {# default('') must bind to contentClass (undefined here); the | filter has higher precedence than ~, so keep it directly on the variable #}
+                                    {% set contentClass = contentClass | default('') ~ ' ' ~ 'text-center' %}
 
-                                {{ parent() }}
-                            {% endblock %}
-                        {% endembed %}
+                                    {{ parent() }}
+                                {% endblock %}
+                            {% endembed %}
+                        </div>
                     {% endfor %}
                 {% endblock %}
             {% endembed %}

--- a/src/Pyz/Yves/ProductSetDetailPage/Theme/default/views/set-detail/set-detail.twig
+++ b/src/Pyz/Yves/ProductSetDetailPage/Theme/default/views/set-detail/set-detail.twig
@@ -48,28 +48,30 @@
             } only %}
                 {% block slides %}
                     {% for image in embed.images %}
-                        {% embed molecule('banner') with {
-                            class: embed.configName,
-                            data: {
-                                imageUrl: image,
-                                title: embed.title,
-                            },
-                        } only %}
-                            {% block content %}
-                                <h1 class="title title--light title--product-set-details">{{ data.title }}</h1>
-                                <p class="{{ config.name }}__text {{ config.name }}__text--subtitle">
-                                    {{- 'product.set' | trans -}}
-                                </p>
-                            {% endblock %}
+                        <div>
+                            {% embed molecule('banner') with {
+                                class: embed.configName ~ '__banner',
+                                data: {
+                                    imageUrl: image,
+                                    title: embed.title,
+                                },
+                            } only %}
+                                {% block content %}
+                                    <h1 class="{{ config.name }}__title">{{ data.title }}</h1>
+                                    <p class="{{ config.name }}__text {{ config.name }}__text--subtitle">
+                                        {{- 'product.set' | trans -}}
+                                    </p>
+                                {% endblock %}
 
-                            {% block body %}
-                                {% set containerClass = config.name ~ '__container grid grid--column grid--middle grid--center' %}
-                                {# default('') must bind to contentClass (undefined here); the | filter has higher precedence than ~, so keep it directly on the variable #}
-                                {% set contentClass = contentClass | default('') ~ ' ' ~ 'text-center' %}
+                                {% block body %}
+                                    {% set containerClass = config.name ~ '__container grid grid--column grid--middle grid--center' %}
+                                    {# default('') must bind to contentClass (undefined here); the | filter has higher precedence than ~, so keep it directly on the variable #}
+                                    {% set contentClass = contentClass | default('') ~ ' ' ~ 'text-center' %}
 
-                                {{ parent() }}
-                            {% endblock %}
-                        {% endembed %}
+                                    {{ parent() }}
+                                {% endblock %}
+                            {% endembed %}
+                        </div>
                     {% endfor %}
                 {% endblock %}
             {% endembed %}


### PR DESCRIPTION
#### Overview

Slick's buildRows() forces `width: 100%; display: inline-block` on the innermost element of every slide. The banner molecule was that element, so its `display: flex` was overridden, `banner__image-wrapper` lost the height it gets from `align-self: stretch` and collapsed to 0, hiding the absolutely positioned lazy-image background.

Wrap each slide in a container so slick's inline styles land there instead of on the banner.

Also drop the stale `title title--light title--product-set-details` classes (no longer defined in SCSS) in favour of `banner__title`, and pass the `product-set-details__banner` class the organism SCSS actually targets.


- Ticket: https://spryker.atlassian.net/browse/CC-39748

