### PR TITLE
Add security fan-out and build steps to the integration skill

### DIFF
--- a/.claude/skills/integration/SKILL.md
+++ b/.claude/skills/integration/SKILL.md
@@ -16,6 +16,20 @@ This skill automates the full integration workflow for applying Spryker package 
 project-level changes from `spryker/suite` into a demoshop. It is primarily focused on
 **b2b-marketplace** but applies to all four demoshops.
 
+Scope: **one ticket, in the demoshop(s) it affects.** Driving a whole bi-weekly BugFix
+Integration round — reading the scope JQL, ordering the tickets, tracking a ledger, closing out
+the umbrella JIRA task — sits above this skill and calls into it per ticket.
+
+| Step | What |
+|------|------|
+| 0–1 | Prerequisites, gather info |
+| 2 | Branch (+ check for an existing PR) |
+| 3–5 | Resolve packages, update `composer.json`, minimal `composer update` |
+| 6 | Apply project-level changes from the suite PR |
+| **6b** | **Security fan-out — all four demoshops** |
+| **6c** | **Build steps: cache / propel migration / transfer / `api:generate`, and verification** |
+| 7–10 | Summary, commit, draft PR, report |
+
 ---
 
 ## Step 0 — Check Prerequisites
@@ -80,7 +94,14 @@ Determine the branch prefix based on the integration type:
 | BugFix / BugFix Integration ticket | `bugfix/` |
 | Security fix | `security/` |
 
-Derive the branch name from the JIRA ticket and a short slug of the ticket title/description:
+Prefer letting `brancho` derive the name from the ticket:
+
+```bash
+brancho branch {TICKET-NUMBER}
+```
+
+If `brancho` is unavailable or its token is rejected, fall back to a hand-derived name using
+the JIRA ticket and a short slug of the ticket title:
 
 ```
 {prefix}{TICKET-NUMBER}-{short-description}
@@ -88,9 +109,23 @@ Derive the branch name from the JIRA ticket and a short slug of the ticket title
 
 **Example:** `integration/abc-1234-update-kernel-package`
 
-Run:
 ```bash
 git checkout -b {branch-name}
+```
+
+If the type is **security**, stop and read *Step 6b — Security fan-out* now: the ticket needs a
+branch in **all four** demoshops, not just this one.
+
+### Check for an existing PR first
+
+Someone may already have integrated this ticket. An open PR means your job is a **rebase**, not
+a fresh integration — do not open a competing PR.
+
+```bash
+gh pr list --repo {demoshop-repo} --state all --limit 60 \
+  --json number,title,state,url \
+  --jq '.[] | select(.title|test("(?i){TICKET-NUMBER}")) | "\(.number) [\(.state)] \(.title) — \(.url)"'
+git branch -a --format='%(refname:short) %(committerdate:short)' | grep -i {TICKET-NUMBER}
 ```
 
 ---
@@ -141,8 +176,20 @@ cat composer.json | grep "vendor/package-name"
 
 ## Step 4 — Update Feature Package Versions in composer.json
 
-For each resolved `spryker-feature/*` package, update its version constraint in the root
-`composer.json` to:
+### 4a — First check whether you need to touch composer.json at all
+
+Most `spryker-feature/*` packages constrain their modules with a caret
+(`spryker/cart: ^7.17.0`), so a **minor** bump of an already-released module needs **no**
+`composer.json` edit — just name the module in the `composer update` of Step 5.
+
+```bash
+composer show spryker-feature/{feature} | sed -n '/requires/,$p' | grep {module}
+```
+
+If the existing constraint already permits the fixed version, skip to Step 5. Editing
+`composer.json` unnecessarily adds noise to the diff and invites an unrelated resolve.
+
+### 4b — Only if the fix is not in any released tag: `dev-master`
 
 ```
 "dev-master as {current-release-tag}"
@@ -152,6 +199,28 @@ For each resolved `spryker-feature/*` package, update its version constraint in 
 ```json
 "spryker-feature/spryker-core": "dev-master as 202602.0"
 ```
+
+> ⚠️ **`dev-master` is not a routine step — it is a last resort, and it needs the user's
+> explicit OK.** Flipping a feature package to `dev-master` pulls in **every** unreleased
+> change in that feature's whole dependency chain, including new `conflict:` declarations that
+> force unrelated majors.
+>
+> This has already bitten us. b2b-demo-marketplace PR #1252 flipped
+> `spryker-feature/self-service-portal` to `dev-master` to reach one `structured_data` column
+> change. That chain's new `conflict: spryker/api-platform <1.23.0` forced api-platform 1.23.0,
+> which forced serializer 1.1.0, which silently changed every `Decimal`-backed API response
+> field from a scale-preserving string (`"1.5000000000"`) to a bare JSON number (`1.5`). The PR
+> went red on `Robot / API B2B` and stayed red — an API wire-format regression out of a
+> column-type ticket.
+>
+> Before flipping, show the user what it drags in:
+> ```bash
+> composer update {feature} --dry-run 2>&1 | grep -E 'Upgrading|Downgrading|Installing|Removing'
+> ```
+> If that list contains anything you cannot explain, the right answer is to wait for the
+> release tag, or to achieve the same effect with a project-level override in `src/Pyz`.
+
+### 4c — Validate
 
 Edit `composer.json` directly. After all changes are made, verify the file is valid JSON:
 
@@ -252,6 +321,36 @@ Go through the diff and identify all changed files. Categorise them:
 
 **IMPORTANT** Changes in src/Spryker, src/SprykerFeature, and src/SprykerShop have to be ignored. These changes are released into the respective repositories which will be updated as explained.
 
+**Also ignore** — these are candidates that are almost never real project changes:
+
+| Path | Why |
+|------|-----|
+| `src/Spryker/*/tests/**`, `**/codeception.yml` | Suite-internal test wiring, not shipped |
+| `.github/workflows/**` | Suite CI. Suite PRs routinely carry along CI fixes belonging to a *different* ticket — read the hunk before assuming it is yours |
+| root `composer.lock` | Third-party drift (aws-sdk, guzzle, doctrine-bundle). Never port |
+
+Conversely, **never dismiss a one-line config flag.** Fixes are often released behind an opt-in
+default of `false`, so the package update alone changes nothing. That single method *is* the
+integration.
+
+### Path translation: suite monorepo → demoshop
+
+Suite nests project files under a per-module wrapper; the demoshops are flat. Strip the wrapper:
+
+```
+suite:    src/Pyz/{Module}/src/Pyz/{Layer}/{Module}/{rest}
+demoshop: src/Pyz/{Layer}/{Module}/{rest}
+```
+
+| Suite path | Demoshop path |
+|------------|---------------|
+| `src/Pyz/Cart/src/Pyz/Zed/Cart/CartConfig.php` | `src/Pyz/Zed/Cart/CartConfig.php` |
+| `src/Pyz/Propel/src/Pyz/Zed/Propel/PropelConfig.php` | `src/Pyz/Zed/Propel/PropelConfig.php` |
+
+`config/**` and `data/**` paths are usually identical in both. Note that a file existing in one
+demoshop does not mean it exists in another — the same ticket can be an edit in b2b-marketplace
+and a brand-new file in b2c-marketplace.
+
 ### Applying changes
 
 For each changed file in the diff:
@@ -276,6 +375,105 @@ Keep a running list of:
 
 ---
 
+## Step 6b — Security Fan-out
+
+> **Skip this step unless the user said this is a security fix.**
+
+A security fix goes into **all four** demoshops, not just the marketplaces. Setting the
+`security/` branch prefix is not the whole job.
+
+A ticket is a security fix if any of these hold: `issuetype = "Security Issue"`; a `Security`
+label or component; or the fix is a CVE, injection, auth/ACL bypass, open redirect, SSRF,
+secret leak, or privilege escalation — regardless of how it is typed. **When it is ambiguous,
+ask.** Do not decide unilaterally that a fix is "not really" security and skip two shops.
+
+Repeat Steps 2–6 in each of the four repos. The legacy shops need extra care because they run a
+release behind:
+
+1. **Check the fixed version is even reachable** from the legacy constraint:
+   ```bash
+   composer why-not vendor/package {fixed-version}
+   ```
+2. **Three options, best first:**
+
+   | Option | When |
+   |--------|------|
+   | Use a backport tag on the legacy series | Always check first — look for a lower patch release carrying the same fix |
+   | Port the fix as a project override in `src/Pyz` | Change is small and self-contained, no backport exists |
+   | Bump the feature constraint | Last resort, needs the user's OK, expect a large lock delta |
+
+   If none is viable, the shop is **deferred with the blocker named** — and because it is a
+   security fix, say so prominently rather than burying it.
+3. **Never change a legacy checkout's git state on the user's behalf.** Read the current branch,
+   report it, and let them decide.
+4. **Expect no CI parity.** The legacy shops do not run the marketplaces' matrix. Verify with
+   static analysis and whatever unit/functional lanes exist, and state plainly that E2E
+   coverage is absent there.
+
+Report one explicit outcome per shop — a PR URL, or the reason there isn't one. "Integrated into
+the demoshops" is not an acceptable summary for a security fix.
+
+---
+
+## Step 6c — Build Steps
+
+Run only what the change actually requires. This is not a blanket ritual.
+
+| Change kind | Required step |
+|-------------|---------------|
+| Config flag / plain PHP in `src/Pyz` | `console cache:empty-all` |
+| `*.schema.xml` | `propel:install` — or `propel:schema:copy` → `propel:model:build` → `propel:diff` → `propel:migrate`. **Inspect the generated migration before applying it.** |
+| `*.transfer.xml` | `transfer:generate` |
+| API Platform `*.resource.yml` / DSL change | `glue api:generate`, then Glue cache clear + warmup per application (`GLUE_STOREFRONT`, and `GLUE_BACKEND` if a backend resource moved) |
+| Any generated-code change | Restart the Glue/PHP containers — OPcache serves stale generated classes otherwise |
+| Frontend (`*.twig`, `assets/**`) | The matching `console frontend:project:build-*` |
+
+### Propel schema overrides
+
+A project override that changes an **existing attribute value** (not merely adds a column) is
+rejected by the schema merger unless whitelisted. A `type` change therefore needs the schema
+file **and**:
+
+```php
+// src/Pyz/Zed/Propel/PropelConfig.php
+/**
+ * @return array<string, array<string>>
+ */
+public function getWhitelistForAllowedAttributeValueChanges(): array
+{
+    return [
+        'spy_product_page_search.schema.xml' => ['type'],
+    ];
+}
+```
+
+Omitting the whitelist produces a merger error at `propel:install`, not a silent no-op.
+
+Column-type migrations on high-volume tables are real `ALTER TABLE` operations — core
+deliberately leaves the biggest tables untouched and expects the project to opt in, which is why
+these arrive as `src/Pyz` overrides. Running one against a shared or running stack needs the
+user's explicit OK.
+
+Verify a column-type migration by asking the database, not the schema file:
+
+```sql
+SELECT TABLE_NAME, DATA_TYPE, CHARACTER_MAXIMUM_LENGTH
+FROM information_schema.COLUMNS
+WHERE COLUMN_NAME = '{column}' AND TABLE_SCHEMA = DATABASE()
+ORDER BY TABLE_NAME;
+```
+
+### Verification
+
+- `vendor/bin/spryker-ci spryker-ci --current` for the static + touched-module gate.
+- The tests that actually cover the change — name them, with file and line.
+- `Robot / API` and `Robot / API B2B` are **pull-request-only** on the marketplaces. A green
+  master proves nothing about them.
+- **Never adjust a test expectation to match new output.** A changed assert is a changed
+  contract; if the values moved, the package moved wrongly and that is a new ticket.
+
+---
+
 ## Step 7 — Summary Before Commit
 
 Before committing, present a summary to the user:
@@ -292,6 +490,10 @@ Security fix:      yes/no
 Composer changes:
   Feature packages updated: {list}
   Packages added directly:  {list or "none"}
+  Packages moved:           {name} {from} → {to}   (one line each)
+
+Build steps run:            {list, or "none required"}
+Verification:               {job or manual check, and its result}
 
 Project changes:
   ✅ Applied cleanly: {count} files
@@ -312,15 +514,18 @@ Once the user confirms, stage and commit all changes:
 
 ```bash
 git add .
-git commit -m "{TICKET-NUMBER}: integrate package updates and project changes from suite PR {PR-number}"
+git commit -m "{TICKET-NUMBER} Integrate package updates and project changes from suite PR {PR-number}"
 git push origin {branch-name}
 ```
 
 If there were conflicts, use this commit message instead:
 
 ```bash
-git commit -m "{TICKET-NUMBER}: integrate package updates from suite PR {PR-number} — ⚠ manual conflict resolution required"
+git commit -m "{TICKET-NUMBER} Integrate package updates from suite PR {PR-number} — ⚠ manual conflict resolution required"
 ```
+
+Commit messages and branch names may reference the JIRA key freely. **The code may not** — never
+put a JIRA key in source, comments, config, or CI files.
 
 After pushing, output the branch URL:
 ```
@@ -331,20 +536,31 @@ https://github.com/{demoshop-repo}/tree/{branch-name}
 
 ## Step 9 — Create Pull Request
 
-Create a pull request targeting `master` using the repo's PR template:
+> **Show the user the exact title and body and wait for an explicit OK before running this.**
+> Creating a PR, editing a PR body, commenting on a PR or JIRA issue, and marking a PR ready are
+> all outward sends — each needs its own approval, and approval for one does not carry to the
+> next.
+
+Create a **draft** pull request targeting `master` using the repo's PR template. Draft matters:
+marking a PR ready fires the full, costly E2E suite.
 
 ```bash
-gh pr create --base master --title "{TICKET-NUMBER}: {short-description}" --body "$(cat <<'EOF'
+gh pr create --draft --base master --title "{TICKET-NUMBER} {Sentence-case summary}" --body "$(cat <<'EOF'
 #### Overview
 
 - Ticket: https://spryker.atlassian.net/browse/{TICKET-NUMBER}
+- Suite PR: https://github.com/spryker/suite/pull/{PR-number}
 
 ###### Change log
 
-- Updated feature packages: {list}
+- Packages: {name} {from} → {to} (one line each)
 - Packages added directly: {list or "none"}
 - Project changes applied from suite PR {PR-number}: {count} files
 - Conflicts requiring manual review: {count} files
+
+###### Test plan
+
+- {the named job or manual check that proves the fix}
 
 ###### CI Notice
 **Additional tests** can be triggered by adding labels:
@@ -358,8 +574,15 @@ EOF
 )"
 ```
 
-- The **title** uses the JIRA ticket number and the short description from the branch name.
-- The **change log** summarises feature packages updated, directly added packages, project changes applied, and conflicts flagged.
+- The **title** is `{TICKET-NUMBER} {Sentence-case summary}` — no colon after the key, and never
+  a `fix(KEY): …` conventional-commit form.
+- The **change log** summarises packages moved (with from→to versions), directly added packages,
+  project changes applied, and conflicts flagged.
+- **One PR per demoshop per ticket.** Tickets that share a package chain share one PR per shop,
+  because they share one `composer update`.
+- Keep the body terse — summary, links, test plan. Detailed analysis belongs in JIRA.
+- Never cite a local file path or a personal notes location in a PR or JIRA body; restate the
+  content inline.
 
 ---
 
@@ -381,12 +604,24 @@ Please add this PR URL to the following tickets:
 
 ## Reference: Demoshop Repositories
 
-| Demoshop | GitHub repo |
-|----------|------------|
-| b2b-marketplace | `spryker-shop/b2b-marketplace-demo-shop` |
-| b2b | `spryker-shop/b2b-demo-shop` |
-| b2c-marketplace | `spryker-shop/c2c-marketplace-demo-shop` |
-| b2c | `spryker-shop/b2c-demo-shop` |
+| Demoshop | GitHub repo | Release line |
+|----------|-------------|--------------|
+| b2b-marketplace | `spryker-shop/b2b-demo-marketplace` | current |
+| b2c-marketplace | `spryker-shop/b2c-demo-marketplace` | current |
+| b2b (legacy) | `spryker-shop/b2b-demo-shop` | one release behind |
+| b2c (legacy) | `spryker-shop/b2c-demo-shop` | one release behind |
+
+Read each shop's release tag off its own `composer.json` (the modal `2026NN.0` across the
+`spryker-feature/*` constraints) — never assume, and never guess "the next one".
+
+A shop that does not install the affected package is **out of scope** for that ticket. Decide
+by the lock, not by the shop's name:
+
+```bash
+jq -r '.packages[] | select(.name=="vendor/package") | .version' composer.lock
+```
+
+Report an out-of-scope shop explicitly. Silently skipping one reads as "covered".
 
 ---
 
@@ -408,15 +643,21 @@ directly to `require` rather than being resolved through a feature package.
 
 - [ ] All required info gathered
 - [ ] On updated master branch
-- [ ] Branch created with correct prefix and naming
+- [ ] No existing PR/branch already carries this ticket (else this is a rebase, not a new PR)
+- [ ] Branch created via `brancho`, or with the correct prefix and naming
 - [ ] All spryker packages resolved to feature packages (or added directly for exceptions)
-- [ ] `composer.json` updated with `dev-master as {tag}` for all feature packages
+- [ ] Existing caret constraints checked **before** editing `composer.json`
+- [ ] Any `dev-master as {tag}` flip approved by the user, with its dry-run delta shown
 - [ ] `composer update` ran for ONLY the named packages + their feature packages (no `--with-dependencies` unless required)
 - [ ] Lock diff verified minimal (`git diff composer.lock | grep '"name":'` shows only intended packages)
 - [ ] `plugin-api-version` in `composer.lock` not downgraded (reverted if composer lowered it)
-- [ ] Suite PR diff fetched and applied (if project changes)
+- [ ] Resulting versions printed from the lock, not assumed
+- [ ] Suite PR diff fetched; non-package files judged individually, paths translated
+- [ ] Required build steps run (cache / propel / transfer / `api:generate`), container restarted if generated code changed
+- [ ] Verification named and run; no test expectation was changed to match new output
+- [ ] Security fix? → all four demoshops handled, one explicit outcome each
 - [ ] Conflicts documented and flagged
 - [ ] Summary confirmed by user
 - [ ] Changes committed and pushed
-- [ ] Pull request created targeting master
+- [ ] Draft pull request created targeting master, after explicit approval of title + body
 - [ ] PR URL shared for ticket updates


### PR DESCRIPTION
#### Overview

Hardens `.claude/skills/integration/SKILL.md` after using it for the week-31 bi-weekly BugFix Integration round (https://spryker.atlassian.net/browse/CC-39818). Documentation only — no application code touched.

###### Change log

- **Corrected the demoshop repo table.** It listed `spryker-shop/b2b-marketplace-demo-shop` and `spryker-shop/c2c-marketplace-demo-shop`; neither exists. Real names are `spryker-shop/b2b-demo-marketplace` and `spryker-shop/b2c-demo-marketplace`. Added how to read a shop's release tag and how to decide scope from the lock instead of the shop name.
- **New Step 6b — security fan-out.** The skill asked "is this a security fix?" only to pick a branch prefix and then never mentioned the legacy shops again. Security fixes belong in all four demoshops; this step covers what counts as one, the `composer why-not` reachability check, the backport / project-override / constraint-bump ladder for the legacy release line, and one explicit reported outcome per shop.
- **New Step 6c — build steps and verification.** `*.schema.xml` was listed as a change category with no action. Adds the propel migration path, the `getWhitelistForAllowedAttributeValueChanges()` requirement for attribute-value overrides, `transfer:generate`, `glue api:generate`, the OPcache container restart, and an `information_schema` check for column-type migrations. Also records that `Robot / API` and `Robot / API B2B` are pull-request-only, and that a test expectation must never be edited to match new output.
- **Step 4 — `dev-master` demoted to a last resort.** Previously the routine step. Now: check the existing caret constraint first (a released minor usually needs no `composer.json` edit at all), and if `dev-master` is genuinely needed, show the `--dry-run` delta and get an explicit OK. Documents the concrete regression: PR #1252 flipped `spryker-feature/self-service-portal` to `dev-master` for one column-type change, which forced api-platform 1.23.0 → serializer 1.1.0 and silently broke the decimal wire format on every API Platform response field.
- **Step 2** — prefer `brancho branch`, and check for an existing PR/branch before opening a competing one.
- **Step 6** — ignore-list for suite CI, suite test wiring and `composer.lock`, plus a suite-monorepo → demoshop path-translation table.
- **Step 9** — draft PRs, explicit approval before outward sends, and a PR title without the colon.
- Scope note in the header: this skill handles one ticket; driving a whole round sits above it.

###### Test plan

Documentation change — no CI signal beyond the credential scan and static analysis. Reviewed by walking the week-31 round through it: PRs #1260, #1261 and b2c #731 were produced following the revised steps.