### PR TITLE
CC-39878: AI Backoffice Assistant UI improvements

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -10285,12 +10285,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker-feature/ai-commerce.git",
-                "reference": "dbc82812162051247b71a0ec3c01a656877e6562"
+                "reference": "b2af09bc0defd4bf8828c7786f97f0eb11e911e7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker-feature/ai-commerce/zipball/dbc82812162051247b71a0ec3c01a656877e6562",
-                "reference": "dbc82812162051247b71a0ec3c01a656877e6562",
+                "url": "https://api.github.com/repos/spryker-feature/ai-commerce/zipball/b2af09bc0defd4bf8828c7786f97f0eb11e911e7",
+                "reference": "b2af09bc0defd4bf8828c7786f97f0eb11e911e7",
                 "shasum": ""
             },
             "require": {
@@ -10360,7 +10360,7 @@
             "support": {
                 "source": "https://github.com/spryker-feature/ai-commerce/tree/master"
             },
-            "time": "2026-07-21T07:56:12+00:00"
+            "time": "2026-07-29T18:09:27+00:00"
         },
         {
             "name": "spryker-feature/alternative-products",


### PR DESCRIPTION
#### Overview

- Ticket: https://spryker.atlassian.net/browse/CC-39878
- Suite PR: https://github.com/spryker/suite/pull/979

###### Change log

- Updated feature packages: `spryker-feature/ai-commerce` (`dev-master dbc8281` → `dev-master b2af09b`)
  - Constraint already `dev-master as 202606.0`, so only `composer.lock` changed.
  - Brings in the docked panel layout for the AI Backoffice Assistant — the chat panel now pushes Back Office page content aside instead of overlapping it.
- Packages added directly: none
- Project changes applied from suite PR 979: 0 files
  - All 6 changed files in the suite PR live under `src/SprykerFeature/AiCommerce/**` and are released via `spryker-feature/ai-commerce`, so no project-level changes are required.
  - Verified the demoshop has no overrides shadowing them (only `src/Pyz/Zed/AiCommerce/AiCommerceConfig.php` exists).
- Conflicts requiring manual review: 0 files

> Note: the change includes Zed SCSS/JS, so a Zed asset build is needed for it to be visible in a running environment.

###### CI Notice
**Additional tests** can be triggered by adding labels:
- `run-compatibility-ci` runs compatibility tests (PHP 8.3 / PostgreSQL / Debian / Prefer Lowest / Dynamic Store OFF):
    - Codeception / Acceptance & API
    - Codeception / Functional Tests
    - Robot / API
    - Robot / UI
    - Cypress / UI