### PR TITLE
CC-39898: run configuration:sync in cloud install recipes

### DIFF
--- a/config/install/destructive.yml
+++ b/config/install/destructive.yml
@@ -41,6 +41,10 @@ sections:
         init-database:
             command: 'vendor/bin/console setup:init-db -vvv --no-ansi'
 
+    configuration:
+        configuration-sync:
+            command: 'vendor/bin/console configuration:sync -vvv --no-ansi'
+
     setup-queue:
         queue-setup:
             command: 'vendor/bin/console queue:setup'

--- a/config/install/dynamic-store.yml
+++ b/config/install/dynamic-store.yml
@@ -25,6 +25,10 @@ sections:
         propel-migration-cleanup:
             command: 'vendor/bin/console propel:migration:delete -vvv --no-ansi'
 
+    configuration:
+        configuration-sync:
+            command: 'vendor/bin/console configuration:sync -vvv --no-ansi'
+
     setup-queue:
         queue-setup:
             command: 'vendor/bin/console queue:setup'

--- a/config/install/production.yml
+++ b/config/install/production.yml
@@ -25,6 +25,10 @@ sections:
         propel-migration-cleanup:
             command: 'vendor/bin/console propel:migration:delete -vvv --no-ansi'
 
+    configuration:
+        configuration-sync:
+            command: 'vendor/bin/console configuration:sync -vvv --no-ansi'
+
     scheduler-start:
         queue-setup:
             command: 'vendor/bin/console queue:setup'


### PR DESCRIPTION
The OpenAI API key appeared to "lose its correctness" after every normal deployment. The stored value was never lost or corrupted - the encrypted row in spy_configuration_value stays intact. What was missing is the configuration schema cache.

`vendor/bin/console configuration:sync` generates
data/cache/configuration/settings-map.php and merged-schema.php. Both are excluded from the git repo (.gitignore, /data/*) and from the Docker image (.dockerignore, /data with re-includes only for import/export/configuration), and are written inside the container - so a freshly deployed container never has them.

Without that cache ConfigurationSchemaReader::getSettingsMap() returns an empty array, so AbstractConfigurationValueResolver::resolveConfigurationValueForKey() returns null for every setting - including ai_vendor:openai:general:api_token - before decryption is ever attempted. No exception and no log entry, which is why this looked like a broken key. The Back Office still displayed the value because the Manage screen builds its form from the YAML schema and reads the raw row directly, so the UI and the runtime resolver disagreed.

The command already ran in config/install/docker.yml and in the CI recipes, but was missing from the recipes a cloud deploy actually invokes. Added it to all three:

- production.yml     SPRYKER_HOOK_INSTALL (4 deploy files)
- destructive.yml    SPRYKER_HOOK_DESTRUCTIVE_INSTALL (5 deploy files)
- dynamic-store.yml  deploy.aws-env-template.yml, the template new
                     environments are cloned from

pre-deploy.yml is intentionally excluded - it runs before the new code and the DB migration, so there is nothing to sync against yet.

The step is placed before any data:import, because the imported configuration-value rows are validated against the settings map by ConfigurationValueSettingKeyValidatorStep, which aborts with "Run console configuration:sync first" when the map is missing.

configuration:sync cannot overwrite user-set values: ConfigurationSchemaSync::sync() only writes those two cache files and never opens a DB connection, so the step is idempotent and safe to run on every deploy.

#### Overview

- Ticket: URL_HERE

###### Change log

{Relevant changes for project level go here.}

###### CI Notice
**Additional tests** can be triggered by adding labels:
- `run-compatibility-ci` runs compatibility tests (PHP 8.3 / PostgreSQL / Debian / Prefer Lowest / Dynamic Store OFF):
    - Codeception / Acceptance & API
    - Codeception / Functional Tests
    - Robot / API
    - Robot / UI
    - Cypress / UI
