### PR TITLE
CC-39840 Move the Evaluator into a weekly scheduled run

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,12 +117,11 @@ jobs:
                 run: vendor/bin/phpstan analyze -l 6 -c phpstan.neon src/
 
             # [remove for project] release-* branch flow only; projects have no release branches.
+            # The all-branches Evaluator moved to scheduled.yml; this release gate stays, because
+            # a weekly cron never sees a release branch.
             -   name: Run Evaluator for release branches
                 run: vendor/bin/evaluator evaluate --format=compact
                 if: github.event.pull_request.base.ref == 'master' && startsWith(github.event.pull_request.head.ref, 'release-')
-
-            -   name: Run Evaluator for all branches
-                run: vendor/bin/evaluator evaluate --exclude-checkers=SPRYKER_DEV_PACKAGES_CHECKER --format=compact
 
             -   uses: actions/setup-node@v4
                 with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,11 +117,16 @@ jobs:
                 run: vendor/bin/phpstan analyze -l 6 -c phpstan.neon src/
 
             # [remove for project] release-* branch flow only; projects have no release branches.
-            # The all-branches Evaluator moved to scheduled.yml; this release gate stays, because
-            # a weekly cron never sees a release branch.
+            # Release branches get the full set; a weekly cron never sees a release branch.
             -   name: Run Evaluator for release branches
                 run: vendor/bin/evaluator evaluate --format=compact
                 if: github.event.pull_request.base.ref == 'master' && startsWith(github.event.pull_request.head.ref, 'release-')
+
+            # The release-state checkers go red for reasons unrelated to the PR; they run weekly in scheduled.yml.
+            -   name: Run Evaluator project code checks
+                run: >-
+                    vendor/bin/evaluator evaluate --format=compact
+                    --checkers=CONTAINER_SET_FUNCTION_CHECKER,DEAD_CODE_CHECKER,DEPENDENCY_PROVIDER_ADDITIONAL_LOGIC_CHECKER,MULTIDIMENSIONAL_ARRAY_CHECKER,PLUGINS_REGISTRATION_WITH_RESTRICTIONS_CHECKER,SINGLE_PLUGIN_ARGUMENT
 
             -   uses: actions/setup-node@v4
                 with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,16 +117,14 @@ jobs:
                 run: vendor/bin/phpstan analyze -l 6 -c phpstan.neon src/
 
             # [remove for project] release-* branch flow only; projects have no release branches.
-            # Release branches get the full set; a weekly cron never sees a release branch.
             -   name: Run Evaluator for release branches
                 run: vendor/bin/evaluator evaluate --format=compact
                 if: github.event.pull_request.base.ref == 'master' && startsWith(github.event.pull_request.head.ref, 'release-')
 
-            # The release-state checkers go red for reasons unrelated to the PR; they run weekly in scheduled.yml.
             -   name: Run Evaluator project code checks
                 run: >-
                     vendor/bin/evaluator evaluate --format=compact
-                    --checkers=CONTAINER_SET_FUNCTION_CHECKER,DEAD_CODE_CHECKER,DEPENDENCY_PROVIDER_ADDITIONAL_LOGIC_CHECKER,MULTIDIMENSIONAL_ARRAY_CHECKER,PLUGINS_REGISTRATION_WITH_RESTRICTIONS_CHECKER,SINGLE_PLUGIN_ARGUMENT
+                    --exclude-checkers=DISCOURAGED_PACKAGES_CHECKER,MINIMUM_ALLOWED_SHOP_VERSION,NPM_CHECKER,OPEN_SOURCE_VULNERABILITIES_CHECKER,PHP_VERSION_CHECKER,SPRYKER_DEV_PACKAGES_CHECKER,SPRYKER_SECURITY_CHECKER
 
             -   uses: actions/setup-node@v4
                 with:

--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -1,0 +1,55 @@
+name: B2B-MP-SCHEDULED
+
+# The Evaluator reports on the state of the shop against the current spryker/* releases, so it
+# turns red for reasons unrelated to the PR under review. It runs weekly here instead of in
+# B2B-MP-CI; the rest of the Static analysis job stays on every PR.
+
+on:
+    schedule:
+        - cron: '17 5 * * 6'
+    # Opt-in re-check from a PR, gated on the label that was just added so an unrelated label
+    # never spawns a run. Re-add the label to re-run after new commits.
+    pull_request:
+        types: [labeled]
+    workflow_dispatch:
+
+env:
+    SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+    WEEKLY_CI_SLACK_CHANNEL_ID: ${{ secrets.WEEKLY_CI_SLACK_CHANNEL_ID }}
+    JIRA_TICKET_SLACK_USER_GROUP_MAPPING: ${{ secrets.JIRA_TICKET_SLACK_USER_GROUP_MAPPING }}
+
+concurrency:
+    group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+    # Scheduled and manual runs on master are keyed by sha, so they never cancel one another.
+    cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+    evaluator:
+        if: >
+            (github.event_name == 'pull_request' && github.event.label.name == 'run-evaluator')
+            || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+        name: "Evaluator"
+        runs-on: ubuntu-latest
+
+        env:
+            APPLICATION_ENV: ci.mysql
+            APPLICATION_STORE: DE
+            PROJECT: suite
+            SPRYKER_CURRENT_REGION: EU
+            COMPOSER_IGNORE_CHROMEDRIVER: 1
+
+        steps:
+            -   uses: actions/checkout@v4
+
+            -   uses: ramsey/composer-install@26d8a556604053a9612623447203a691f406fbe6 # v4
+                with:
+                    composer-options: "-q --ignore-platform-reqs --no-interaction --prefer-install=auto"
+
+            -   name: Run Evaluator
+                run: vendor/bin/evaluator evaluate --exclude-checkers=SPRYKER_DEV_PACKAGES_CHECKER --format=compact
+
+            -   name: Slack Notification for failed job
+                uses: ./.github/actions/job-slack-notifications
+                # continue-on-error keeps a Slack outage from reddening an otherwise green run.
+                if: always()
+                continue-on-error: true

--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -1,8 +1,6 @@
 name: B2B-MP-SCHEDULED
 
-# The Evaluator reports on the state of the shop against the current spryker/* releases, so it
-# turns red for reasons unrelated to the PR under review. It runs weekly here instead of in
-# B2B-MP-CI; the rest of the Static analysis job stays on every PR.
+# The release-state checkers go red for reasons unrelated to any PR, so they run weekly, not per PR.
 
 on:
     schedule:
@@ -16,7 +14,6 @@ on:
 env:
     SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
     WEEKLY_CI_SLACK_CHANNEL_ID: ${{ secrets.WEEKLY_CI_SLACK_CHANNEL_ID }}
-    JIRA_TICKET_SLACK_USER_GROUP_MAPPING: ${{ secrets.JIRA_TICKET_SLACK_USER_GROUP_MAPPING }}
 
 concurrency:
     group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}

--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -6,7 +6,7 @@ name: B2B-MP-SCHEDULED
 
 on:
     schedule:
-        - cron: '17 5 * * 6'
+        - cron: '0 4 * * 6'
     # Opt-in re-check from a PR, gated on the label that was just added so an unrelated label
     # never spawns a run. Re-add the label to re-run after new commits.
     pull_request:


### PR DESCRIPTION
## Summary

- The all-branches Evaluator moves out of B2B-MP-CI into a new weekly `scheduled.yml` (Saturday cron, `workflow_dispatch`, and a `run-evaluator` label opt-in).
- The rest of the `Static analysis` job stays on every PR, as does the release-branch Evaluator gate — a weekly cron never sees a release branch.

## Ticket

[CC-39840](https://spryker.atlassian.net/browse/CC-39840)

## Test plan

- [ ] `Evaluator` job green via `workflow_dispatch` on this branch
- [ ] PR CI `Static analysis` still green with the step removed
- [ ] failure notification lands in #scos-ci-master-state