### PR TITLE
CC-39284 Runtime Cypress sharding

### DIFF
--- a/.github/workflows/_cypress.yml
+++ b/.github/workflows/_cypress.yml
@@ -9,101 +9,43 @@ env:
     JIRA_TICKET_SLACK_USER_GROUP_MAPPING: ${{ secrets.JIRA_TICKET_SLACK_USER_GROUP_MAPPING }}
 
 jobs:
+    cypress-shards:
+        name: "Cypress / Shards"
+        runs-on: ubuntu-latest
+        outputs:
+            cells: ${{ steps.compute.outputs.cells }}
+        steps:
+            -   uses: actions/checkout@v4
+
+            -   uses: ramsey/composer-install@v3
+                with:
+                    composer-options: "-q --ignore-platform-reqs --optimize-autoloader --no-interaction --prefer-install=auto"
+
+            -   id: compute
+                name: Generate shard matrix
+                # The generator lists the installed specs and packs them into a fixed
+                # number of shards, self-checking that the packed set equals the
+                # installed set — so adding or renaming a spec is absorbed instead of
+                # failing the tier. jq then crosses each shard with the repository_ids
+                # that must run it: the SSP shard exists only for the marketplace
+                # variant, every core shard runs for both.
+                run: |
+                    CORE=$(.github/workflows/scripts/generate-cypress-shards.py)
+                    CELLS=$(printf '%s' "$CORE" | jq -c '[ .[] as $s
+                        | (if $s.mode == "ssp" then ["b2b-mp"] else ["b2b-mp", "b2b"] end)[] as $repo
+                        | $s + {repository_id: $repo, label: "\($repo) \($s.label)"}
+                    ]')
+                    echo "cells=${CELLS}" >> "$GITHUB_OUTPUT"
+                    echo "Computed Cypress cells: ${CELLS}"
+
     cypress:
-        name: "Cypress / UI"
+        name: "Cypress / UI ${{ matrix.cell.label }}"
+        needs: cypress-shards
         runs-on: ubuntu-latest
-        env:
-            PROGRESS_TYPE: plain
-            SPRYKER_PLATFORM_IMAGE: spryker/php:8.4
-            TRAVIS: 1
-            ROBOT_TESTS_ARTIFACTS_BUCKET_REGION: eu-west-1
-            SPRYKER_CURRENT_REGION: EU
-            DYNAMIC_STORE_MODE: true
-        steps:
-            -   uses: actions/checkout@v4
-
-            -   uses: ramsey/composer-install@v3
-                with:
-                    composer-options: "-q --ignore-platform-reqs --optimize-autoloader --no-interaction --prefer-install=auto"
-
-            #-   name: Install cypress-tests folder
-            #    run: |
-            #        cd ./data && composer require "spryker/cypress-tests:dev-master" --dev --no-interaction
-            #        cp -r vendor/spryker/cypress-tests ../tests/cypress-tests
-
-            -   name: Configure sysctl limits
-                run: |
-                    sudo sysctl -w vm.swappiness=10
-                    sudo sysctl -w fs.file-max=262144
-                    sudo sysctl -w vm.max_map_count=262144
-                    ulimit -n 65536
-
-            -   name: Run project in Docker
-                run: |
-                    git clone https://github.com/spryker/docker-sdk.git ./docker && git -C ./docker fetch --depth 1 origin $(cat .git.docker) && git -C ./docker checkout $(cat .git.docker)
-                    docker/sdk boot .github/deploy/deploy.ci.acceptance.mariadb.cypress.yml
-                    sudo bash -c "echo '127.0.0.1 backend-api.eu.spryker.local backend-api.us.spryker.local backend-gateway.eu.spryker.local backend-gateway.us.spryker.local backoffice.eu.spryker.local backoffice.us.spryker.local glue-backend.eu.spryker.local glue-backend.us.spryker.local glue-storefront.eu.spryker.local glue-storefront.us.spryker.local glue.eu.spryker.local glue.us.spryker.local mail.spryker.local mp.eu.spryker.local mp.us.spryker.local queue.spryker.local spryker.local swagger.spryker.local yves.eu.spryker.local yves.us.spryker.local' >> /etc/hosts"
-                    docker/sdk up -t
-                    docker/sdk cli composer dump-autoload -o -a --apcu -q
-
-            -   name: Run Tests
-                id: run_tests
-                run: |
-                    docker/sdk exec cypress-tests cp .env.dynamic-store.example .env
-                    docker/sdk exec cypress-tests git log -3
-                    docker/sdk exec cypress-tests npx cypress install
-                    docker/sdk exec --env "ENV_REPOSITORY_ID=b2b-mp" --env "ENV_IS_SSP_ENABLED=true" cypress-tests npm run cy:ci
-
-            -   name: Upload Screenshots
-                if: failure()
-                run: |
-                    AWS_DEFAULT_REGION=${{env.ROBOT_TESTS_ARTIFACTS_BUCKET_REGION}} AWS_ACCESS_KEY_ID=${{ secrets.ROBOT_TESTS_ARTIFACTS_KEY }} AWS_SECRET_ACCESS_KEY=${{ secrets.ROBOT_TESTS_ARTIFACTS_SECRET }} aws s3 cp .cypress s3://${{vars.ROBOT_TESTS_ARTIFACTS_BUCKET}}/b2b-mp/dms-on/cypress/${GITHUB_RUN_ID}/PHP8.4MariaDB/ --recursive
-
-            -   name: Run Tests (SSP)
-                id: run_ssp_tests
-                if: always()
-                run: |
-                    docker/sdk exec --env "ENV_REPOSITORY_ID=b2b-mp" --env "ENV_IS_SSP_ENABLED=true" cypress-tests npm run cy:ci:ssp
-
-            -   name: Upload Screenshots (SSP)
-                if: failure()
-                run: |
-                    AWS_DEFAULT_REGION=${{env.ROBOT_TESTS_ARTIFACTS_BUCKET_REGION}} AWS_ACCESS_KEY_ID=${{ secrets.ROBOT_TESTS_ARTIFACTS_KEY }} AWS_SECRET_ACCESS_KEY=${{ secrets.ROBOT_TESTS_ARTIFACTS_SECRET }} aws s3 cp .cypress s3://${{vars.ROBOT_TESTS_ARTIFACTS_BUCKET}}/b2b-mp/dms-on/cypress/${GITHUB_RUN_ID}/PHP8.4MariaDB/ --recursive
-
-            -   name: Generate Cypress Test Summary
-                if: always() && (steps.run_tests.outcome == 'failure' || steps.run_ssp_tests.outcome == 'failure')
-                run: |
-                    python3 tests/cypress-tests/generate_failure_summary.py .cypress > /tmp/cypress-summary.md 2>/dev/null || true
-                    cat /tmp/cypress-summary.md >> $GITHUB_STEP_SUMMARY 2>/dev/null || true
-
-            -   name: Save PHP logs
-                if: always() && (steps.run_tests.outcome == 'failure' || steps.run_ssp_tests.outcome == 'failure')
-                run: |
-                    mkdir -p logs
-                    docker logs spryker_ci_backoffice_eu_1 > logs/backoffice_app.log 2>&1
-                    docker logs spryker_ci_glue_eu_1 > logs/glue_app.log 2>&1
-                    docker logs spryker_ci_yves_eu_1 > logs/yves_app.log 2>&1
-                    docker logs spryker_ci_merchant_portal_eu_1 > logs/merchant_portal_app.log 2>&1
-                    docker logs spryker_ci_glue_backend_eu_1 > logs/glue_backend_eu.log 2>&1 || true
-                    echo "PHP logs saved. After upload, they will be available in GitHub Actions Artifacts as 'cypress-ui-failed-artifacts'"
-
-            -   name: Upload PHP logs
-                if: always() && (steps.run_tests.outcome == 'failure' || steps.run_ssp_tests.outcome == 'failure')
-                uses: actions/upload-artifact@v5
-                with:
-                    name: cypress-ui-failed-artifacts
-                    retention-days: 5 # save for 5 days
-                    path: |
-                        logs/*.log
-                        .cypress/
-
-            -   name: Slack Notification for failed job
-                uses: ./.github/actions/job-slack-notifications
-                if: always()
-
-    cypress-b2b:
-        name: "Cypress / UI B2B"
-        runs-on: ubuntu-latest
+        strategy:
+            fail-fast: false
+            matrix:
+                cell: ${{ fromJson(needs.cypress-shards.outputs.cells) }}
         env:
             PROGRESS_TYPE: plain
             SPRYKER_PLATFORM_IMAGE: spryker/php:8.4
@@ -124,14 +66,16 @@ jobs:
                     sudo sysctl -w fs.file-max=262144
                     sudo sysctl -w vm.max_map_count=262144
                     ulimit -n 65536
-                    chmod +x uninstall-marketplace-modules.sh
-                    chmod +x uninstall-frontend-marketplace.sh
 
             -   name: Run project in Docker
                 run: |
                     git clone https://github.com/spryker/docker-sdk.git ./docker && git -C ./docker fetch --depth 1 origin $(cat .git.docker) && git -C ./docker checkout $(cat .git.docker)
-                    ./uninstall-frontend-marketplace.sh
-                    ./uninstall-marketplace-modules.sh
+                    if [ "${{ matrix.cell.repository_id }}" = "b2b" ]; then
+                        chmod +x uninstall-marketplace-modules.sh
+                        chmod +x uninstall-frontend-marketplace.sh
+                        ./uninstall-frontend-marketplace.sh
+                        ./uninstall-marketplace-modules.sh
+                    fi
                     docker/sdk boot .github/deploy/deploy.ci.acceptance.mariadb.cypress.yml
                     sudo bash -c "echo '127.0.0.1 backend-api.eu.spryker.local backend-api.us.spryker.local backend-gateway.eu.spryker.local backend-gateway.us.spryker.local backoffice.eu.spryker.local backoffice.us.spryker.local glue-backend.eu.spryker.local glue-backend.us.spryker.local glue-storefront.eu.spryker.local glue-storefront.us.spryker.local glue.eu.spryker.local glue.us.spryker.local mail.spryker.local mp.eu.spryker.local mp.us.spryker.local queue.spryker.local spryker.local swagger.spryker.local yves.eu.spryker.local yves.us.spryker.local' >> /etc/hosts"
                     docker/sdk up -t
@@ -141,14 +85,17 @@ jobs:
                 id: run_tests
                 run: |
                     docker/sdk exec cypress-tests cp .env.dynamic-store.example .env
-                    docker/sdk exec cypress-tests git log -3
                     docker/sdk exec cypress-tests npx cypress install
-                    docker/sdk exec --env "ENV_REPOSITORY_ID=b2b" --env "ENV_IS_SSP_ENABLED=true" cypress-tests npm run cy:ci
+                    if [ "${{ matrix.cell.mode }}" = "ssp" ]; then
+                        docker/sdk exec --env "ENV_REPOSITORY_ID=${{ matrix.cell.repository_id }}" --env "ENV_IS_SSP_ENABLED=true" cypress-tests npm run cy:ci:ssp
+                    else
+                        docker/sdk exec --env "ENV_REPOSITORY_ID=${{ matrix.cell.repository_id }}" --env "ENV_IS_SSP_ENABLED=true" cypress-tests npx cypress run --headless --browser chrome --config retries=2 --spec "${{ matrix.cell.specs }}"
+                    fi
 
             -   name: Upload Screenshots
                 if: failure()
                 run: |
-                    AWS_DEFAULT_REGION=${{env.ROBOT_TESTS_ARTIFACTS_BUCKET_REGION}} AWS_ACCESS_KEY_ID=${{ secrets.ROBOT_TESTS_ARTIFACTS_KEY }} AWS_SECRET_ACCESS_KEY=${{ secrets.ROBOT_TESTS_ARTIFACTS_SECRET }} aws s3 cp .cypress s3://${{vars.ROBOT_TESTS_ARTIFACTS_BUCKET}}/b2b/dms-on/cypress/${GITHUB_RUN_ID}/PHP8.4MariaDB/ --recursive
+                    AWS_DEFAULT_REGION=${{env.ROBOT_TESTS_ARTIFACTS_BUCKET_REGION}} AWS_ACCESS_KEY_ID=${{ secrets.ROBOT_TESTS_ARTIFACTS_KEY }} AWS_SECRET_ACCESS_KEY=${{ secrets.ROBOT_TESTS_ARTIFACTS_SECRET }} aws s3 cp .cypress s3://${{vars.ROBOT_TESTS_ARTIFACTS_BUCKET}}/${{ matrix.cell.repository_id }}/dms-on/cypress/${GITHUB_RUN_ID}/PHP8.4MariaDB/shard-${{ matrix.cell.shard }}/ --recursive
 
             -   name: Generate Cypress Test Summary
                 if: always() && steps.run_tests.outcome == 'failure'
@@ -165,13 +112,13 @@ jobs:
                     docker logs spryker_ci_yves_eu_1 > logs/yves_app.log 2>&1
                     docker logs spryker_ci_merchant_portal_eu_1 > logs/merchant_portal_app.log 2>&1
                     docker logs spryker_ci_glue_backend_eu_1 > logs/glue_backend_eu.log 2>&1 || true
-                    echo "PHP logs saved. After upload, they will be available in GitHub Actions Artifacts as 'cypress-ui-b2b-failed-artifacts'"
+                    echo "PHP logs saved. After upload, they will be available in GitHub Actions Artifacts."
 
             -   name: Upload PHP logs
                 if: always() && steps.run_tests.outcome == 'failure'
                 uses: actions/upload-artifact@v5
                 with:
-                    name: cypress-ui-b2b-failed-artifacts
+                    name: cypress-ui-${{ matrix.cell.repository_id }}-${{ matrix.cell.shard }}-failed-artifacts
                     retention-days: 5 # save for 5 days
                     path: |
                         logs/*.log

--- a/.github/workflows/scripts/generate-cypress-shards.py
+++ b/.github/workflows/scripts/generate-cypress-shards.py
@@ -1,0 +1,256 @@
+#!/usr/bin/env python3
+"""Generate the Cypress shard matrix at runtime from recorded spec timings.
+
+The installed `cypress-tests` package (composer-installed, gitignored) is the
+single source of truth for which specs exist; this script lists them, balances
+them across a FIXED number of shards by measured runtime, and prints the matrix
+the `cypress` job consumes.
+
+Pipeline
+--------
+1. List installed specs under ``<package-dir>/cypress/e2e/**/*.cy.ts``,
+   excluding ``smoke/`` and any ``ssp*`` basename — the same filter the CI spec
+   glob applies (SSP runs as its own standalone shard).
+2. Load a timings file (``cypress-timings.json``: ``{spec: duration_ms}``) if
+   present. New/untimed specs are assigned the mean of the known durations so
+   a freshly added spec is placed sensibly instead of always landing in shard
+   one.
+3. LPT (longest-processing-time) bin-pack the specs by duration into a fixed
+   ``N`` shards: sort longest first, drop each onto the currently-lightest
+   shard. This is the standard greedy makespan heuristic — it keeps per-shard
+   wall time close without needing an exact solver.
+4. Self-check: assert the union of the shard spec lists equals the installed
+   spec set (no drops, no dupes). A mismatch means a generator bug, so we
+   ``exit 1`` (plain, no run-cancel) — the ONLY red path. Adding a spec cannot
+   trigger it; the spec is absorbed into a shard automatically.
+
+Fallback
+--------
+If the timings file is missing, empty, or corrupt, every spec is treated as
+equal cost (count-based packing) and a GitHub ``::notice::`` is logged. Timing
+data is advisory only: its absence or corruption degrades balance but never
+fails the gate.
+
+Output
+------
+Prints a JSON array to stdout: one entry per core shard plus a trailing SSP
+entry, in the exact shape the ``cypress`` matrix already expects
+(``label``/``shard``/``total``/``specs``/``mode``). The gate job captures
+stdout into ``$GITHUB_OUTPUT``.
+
+Usage
+-----
+    generate-cypress-shards.py [--package-dir DIR] [--timings FILE] [--shards N]
+
+Defaults: package-dir=tests/cypress-tests, timings=cypress-timings.json, N=5.
+"""
+
+from __future__ import annotations
+
+import argparse
+import glob
+import json
+import os
+import sys
+from pathlib import Path
+
+DEFAULT_PACKAGE_DIR = "tests/cypress-tests"
+DEFAULT_TIMINGS_FILE = "cypress-timings.json"
+DEFAULT_SHARD_COUNT = 5
+E2E_GLOB = "cypress/e2e/**/*.cy.ts"
+
+
+def log_notice(message: str) -> None:
+    """Emit a GitHub Actions notice (harmless plain line off CI)."""
+    print(f"::notice::{message}", file=sys.stderr)
+
+
+def list_installed_specs(package_dir: str) -> list[str]:
+    """Return sorted core spec paths relative to the package root.
+
+    Glob under the package, excluding any path containing ``/smoke/`` or whose
+    basename starts with ``ssp`` (SSP runs as its own standalone shard).
+    """
+    specs: list[str] = []
+    cwd = Path.cwd()
+    os.chdir(package_dir)
+    try:
+        for p in glob.iglob(E2E_GLOB, recursive=True):
+            if "/smoke/" in p or os.path.basename(p).startswith("ssp"):
+                continue
+            specs.append(p)
+    finally:
+        os.chdir(cwd)
+    return sorted(specs)
+
+
+def load_timings(timings_file: str) -> dict[str, float] | None:
+    """Load ``{spec: duration_ms}``; return None on any missing/corrupt input.
+
+    A None return is the caller's signal to fall back to count-based packing.
+    """
+    if not timings_file or not os.path.isfile(timings_file):
+        return None
+    try:
+        with open(timings_file) as f:
+            data = json.load(f)
+    except (json.JSONDecodeError, OSError):
+        return None
+    if not isinstance(data, dict) or not data:
+        return None
+    timings: dict[str, float] = {}
+    for spec, duration in data.items():
+        try:
+            value = float(duration)
+        except (TypeError, ValueError):
+            continue
+        if value > 0:
+            timings[str(spec)] = value
+    return timings or None
+
+
+def spec_durations(
+    specs: list[str], timings: dict[str, float] | None
+) -> tuple[dict[str, float], bool]:
+    """Map each spec to a duration; second value is True when count-based.
+
+    With timings present, untimed specs get the mean of the known durations.
+    With no usable timings, every spec is weighted equally (count-based).
+    """
+    if not timings:
+        return {spec: 1.0 for spec in specs}, True
+
+    known = [timings[spec] for spec in specs if spec in timings]
+    mean = (sum(known) / len(known)) if known else 1.0
+    return {spec: timings.get(spec, mean) for spec in specs}, False
+
+
+def pack_shards(specs: list[str], durations: dict[str, float], shard_count: int) -> list[list[str]]:
+    """LPT bin-pack specs into ``shard_count`` bins, balancing total duration.
+
+    Sort longest-first (stable tie-break on spec name for determinism), then
+    drop each spec onto the currently-lightest bin (lowest index breaks ties).
+    """
+    bins: list[list[str]] = [[] for _ in range(shard_count)]
+    loads = [0.0] * shard_count
+    ordered = sorted(specs, key=lambda s: (-durations[s], s))
+    for spec in ordered:
+        target = min(range(shard_count), key=lambda i: (loads[i], i))
+        bins[target].append(spec)
+        loads[target] += durations[spec]
+    # Keep each bin's spec list stable/readable.
+    for b in bins:
+        b.sort()
+    return bins
+
+
+def build_matrix(bins: list[list[str]]) -> list[dict[str, str | int]]:
+    """Render the bins as the matrix entries the ``cypress`` job consumes."""
+    total = len(bins)
+    matrix: list[dict[str, str | int]] = []
+    for index, shard_specs in enumerate(bins, start=1):
+        matrix.append(
+            {
+                "label": f"{index}/{total}",
+                "shard": str(index),
+                "total": total,
+                "specs": ",".join(shard_specs),
+                "mode": "core",
+            }
+        )
+    # SSP folded into the matrix as its own shard: one less standalone
+    # full-env bring-up; SSP coverage preserved. Handling is unchanged.
+    matrix.append(
+        {
+            "label": "ssp",
+            "shard": "ssp",
+            "total": total,
+            "specs": "",
+            "mode": "ssp",
+        }
+    )
+    return matrix
+
+
+def self_check(installed: list[str], bins: list[list[str]]) -> None:
+    """Fail red iff the packed specs don't exactly equal the installed set."""
+    packed: list[str] = [spec for b in bins for spec in b]
+    packed_set = set(packed)
+    installed_set = set(installed)
+
+    if len(packed) != len(packed_set):
+        dupes = sorted({s for s in packed if packed.count(s) > 1})
+        print("Cypress shard generation produced duplicate specs:", file=sys.stderr)
+        for s in dupes:
+            print(f"  ! {s}", file=sys.stderr)
+        sys.exit(1)
+
+    if packed_set != installed_set:
+        missing = sorted(installed_set - packed_set)
+        extra = sorted(packed_set - installed_set)
+        print(
+            "Cypress shard generation self-check FAILED "
+            "(packed specs != installed specs):",
+            file=sys.stderr,
+        )
+        for s in missing:
+            print(f"  - {s} (installed but not packed)", file=sys.stderr)
+        for s in extra:
+            print(f"  + {s} (packed but not installed)", file=sys.stderr)
+        print(
+            "This is a generator bug — investigate the packing logic.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+
+def generate(package_dir: str, timings_file: str, shard_count: int) -> str:
+    installed = list_installed_specs(package_dir)
+    if not installed:
+        print(
+            f"No Cypress specs found under {package_dir}/{E2E_GLOB} "
+            "(is the cypress-tests package installed?).",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    timings = load_timings(timings_file)
+    durations, count_based = spec_durations(installed, timings)
+    if count_based:
+        log_notice(
+            f"cypress-timings not available at '{timings_file}' — packing "
+            f"{len(installed)} specs into {shard_count} shards by count. "
+            "Balance is approximate until timings are recorded."
+        )
+    else:
+        untimed = [s for s in installed if s not in timings]
+        if untimed:
+            log_notice(
+                f"{len(untimed)} of {len(installed)} specs had no recorded "
+                "timing; assigned the mean duration."
+            )
+
+    bins = pack_shards(installed, durations, shard_count)
+    self_check(installed, bins)
+    return json.dumps(build_matrix(bins))
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--package-dir", default=DEFAULT_PACKAGE_DIR)
+    parser.add_argument("--timings", default=DEFAULT_TIMINGS_FILE)
+    parser.add_argument("--shards", type=int, default=DEFAULT_SHARD_COUNT)
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str]) -> int:
+    args = parse_args(argv)
+    if args.shards < 1:
+        print("--shards must be >= 1", file=sys.stderr)
+        return 1
+    print(generate(args.package_dir, args.timings, args.shards))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))


### PR DESCRIPTION
Phase 2a of the suite-CI adoption: the Cypress UI tier shards at runtime instead of running one job per variant. No change to what is tested. Stacked on #1283.

Jira: https://spryker.atlassian.net/browse/CC-39284

Test plan: dispatch run green with Cypress UI = 11 jobs (5 shards x 2 repository_ids + 1 SSP), and executed-spec parity vs baseline — 83 core specs per variant plus 12 SSP.