### PR TITLE
Set inline factories for non-dockerdev environments

### DIFF
--- a/config/Glue/packages/framework.php
+++ b/config/Glue/packages/framework.php
@@ -10,9 +10,10 @@ declare(strict_types = 1);
 /**
  * @see config/README.md for more information about this configuration.
  */
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 use Symfony\Config\FrameworkConfig;
 
-return static function (FrameworkConfig $framework, string $env): void {
+return static function (FrameworkConfig $framework, ContainerConfigurator $container, string $env): void {
     $framework->secret('spryker-glue-secret');
 
     $framework->assets([

--- a/config/Glue/packages/framework.php
+++ b/config/Glue/packages/framework.php
@@ -20,4 +20,8 @@ return static function (FrameworkConfig $framework, string $env): void {
     ]);
 
     $framework->test($env === 'dockerdev');
+    
+    if ($env !== 'dockerdev') {
+        $container->parameters()->set('.container.dumper.inline_factories', true);
+    }
 };

--- a/config/GlueBackend/packages/framework.php
+++ b/config/GlueBackend/packages/framework.php
@@ -20,4 +20,7 @@ return static function (FrameworkConfig $framework, string $env): void {
         ]);
 
     $framework->test($env === 'dockerdev');
+    if ($env !== 'dockerdev') {
+        $container->parameters()->set('.container.dumper.inline_factories', true);
+    }
 };

--- a/config/GlueBackend/packages/framework.php
+++ b/config/GlueBackend/packages/framework.php
@@ -10,9 +10,10 @@ declare(strict_types = 1);
 /**
  * @see config/README.md for more information about this configuration.
  */
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 use Symfony\Config\FrameworkConfig;
 
-return static function (FrameworkConfig $framework, string $env): void {
+return static function (FrameworkConfig $framework, ContainerConfigurator $container, string $env): void {
     $framework->secret('spryker-glue-backend-secret');
 
     $framework->assets([


### PR DESCRIPTION
#### Overview

- Ticket: URL_HERE

###### Change log

{Relevant changes for project level go here.}

###### CI Notice
**Additional tests** can be triggered by adding labels:
- `run-compatibility-ci` runs compatibility tests (PHP 8.3 / PostgreSQL / Debian / Prefer Lowest / Dynamic Store OFF):
    - Codeception / Acceptance & API
    - Codeception / Functional Tests
    - Robot / API
    - Robot / UI
    - Cypress / UI
