### PR TITLE
OPS-5431: reseed config-derived DB records on normal deploy to fix backend-api invalid_client

### DIFF
--- a/config/install/production.yml
+++ b/config/install/production.yml
@@ -29,6 +29,14 @@ sections:
         configuration-sync:
             command: 'vendor/bin/console configuration:sync -vvv --no-ansi'
 
+    # Re-seeds config-derived DB records (OAuth clients, scopes, ACL, permissions) so that rotated
+    # secrets injected into the containers stay in sync with their hashes in the database.
+    # Without this a normal deploy leaves spy_oauth_client holding the previous secret hash and the
+    # backend API /token endpoint fails with invalid_client until a destructive deploy reseeds it.
+    init-db:
+        setup-init-db:
+            command: 'vendor/bin/console setup:init-db -vvv --no-ansi'
+
     scheduler-start:
         queue-setup:
             command: 'vendor/bin/console queue:setup'


### PR DESCRIPTION
## Problem

`POST https://glue-backend.eu.icp-plus.sh01.demo-spryker.com/token` returns

```json
[{"status":400,"code":"invalid_client","message":"Client authentication failed"}]
```

instead of `200` + access token. It breaks **periodically after a normal deploy** and is "fixed" by a **destructive** deploy. Reproduced live on ICP-PLUS at 2026-08-11 08:04 UTC (still broken at time of writing — no destructive deploy since 10 Aug).

## Root cause — deploy-process gap, not application code

1. The `spryker-icpplus-provision` pipeline rewrites all `/spryker-icpplus/custom-secrets/*` SSM parameters on each apply. `SPRYKER_OAUTH_CLIENT_SECRET` and `SPRYKER_OAUTH_CLIENT_CONFIGURATION` were both rotated to **v19 on 2026-08-10 16:42 UTC+3**, and to v17/v18 on 20–21 Jul.
2. `spy_oauth_client` stores a **bcrypt hash** of that secret. It is written only by `OauthClientInstaller`, registered as `OauthClientInstallerPlugin` in `src/Pyz/Zed/Installer/InstallerDependencyProvider.php:62` and executed by **`setup:init-db`**.
3. `setup:init-db` appeared in **`config/install/destructive.yml` only** — never in `config/install/production.yml`, which is what `SPRYKER_HOOK_INSTALL` runs on a normal deploy. Neither `pre-deploy.yml` nor the icpplus after-deploy hook reseeds it either.
4. So after a rotation the containers hold the **new** secret while the database still holds the hash of the **old** one. `password_verify()` fails at `vendor/spryker/oauth/src/Spryker/Zed/Oauth/Business/Model/League/Repositories/ClientRepository.php:73`, `league/oauth2-server` throws `invalid_client`, and the endpoint 400s.
5. A destructive deploy drops the tables and runs `setup:init-db`, reseeding the row from the current environment — hence the apparent fix.

Verified in the 10 Aug install CodeBuild log: it ran `Install production environment` (25.96s) with **no** `setup:init-db` and no oauth step. Note also there was **no image build on 10 Aug** (that deploy shipped the 5 Aug image), so no application-code change is implicated.

### Timeline

| When | Event |
|---|---|
| 20–21 Jul | PROVISION succeeds → oauth secret → v17, v18 |
| 30–31 Jul | NORMAL deploys first inject v18 into containers → **broken** |
| 31 Jul 17:37 | **DESTRUCTIVE** deploy → reseeded → fixed |
| 10 Aug 16:32→16:42 | PROVISION succeeds → oauth secret → **v19** |
| 10 Aug 16:53 | NORMAL deploy → containers load v19, DB still on v18 → **broken** |
| since | no destructive deploy → **still broken** |

The trigger is the **container restart that first loads a rotated secret**, which can lag the SSM write by days (that is why 31 Jul had no same-day rotation).

## Fix

Add a `setup:init-db` step to `config/install/production.yml` so config-derived DB records are reconciled on every normal deploy.

This is safe to re-run: because `SPRYKER_OAUTH_CLIENT_CONFIGURATION` is set in this environment, `OauthClientInstaller::install()` takes the configured branch, and `OauthClientWriter::save()` is a genuine **upsert** — it calls `updateClient()` when the identifier already exists rather than inserting a duplicate. Installer plugins are designed to be idempotent ("Fill the database with required data"), and `destructive.yml` already depends on this same command.

Placed after `configuration:sync` (config in place) and after the propel migration steps (schema in place), before `data-import`/`acl` — mirroring the ordering in `destructive.yml`.

## Reviewer notes / open points

- **Scope of the change is wider than OAuth.** `setup:init-db` has no per-plugin filter, so this runs all ~20 installer plugins on every normal deploy (ACL, glossary, countries, permissions, `DynamicEntityInstallerPlugin`, `UserInstallerPlugin`, …). They are intended to be idempotent, but please confirm that is acceptable on a live production DB for this env — particularly `UserInstallerPlugin`. If not, the alternative is a narrower dedicated console command that installs only the OAuth client.
- Adds ~a few seconds to normal-deploy time (destructive install is 6–9 min vs normal ≈90 s today).
- **Not proven by log evidence:** the app never logs the `invalid_client` string, so the secret-mismatch step is established from the code path + recipe gap + rotation timeline, not from a log line. SSM `SecureString` values could not be decrypted under the read-only access used here, so the DB-hash-vs-current-secret comparison was not made directly.
- `SPRYKER_OAUTH_CLIENT_IDENTIFIER` has never been rotated (v1 since 4 Mar, `frontend`), which is why the row is always found and the failure is a secret mismatch rather than an unknown client.
- **This does not fix the currently broken environment** — it prevents recurrence. ICP-PLUS still needs a one-off reseed (run `setup:init-db` in the env, or a destructive deploy).

Ticket: https://spryker.atlassian.net/browse/OPS-5431
